### PR TITLE
[✨ Feature] 프로필 수정 페이지 마크업 및 기능 구현

### DIFF
--- a/moamoa/.eslintrc.json
+++ b/moamoa/.eslintrc.json
@@ -12,15 +12,12 @@
   },
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-<<<<<<< HEAD
     "react/react-in-jsx-scope": "off",
     "no-console": "off",
     "no-alert": "off",
     "no-shadow": "off",
     "dot-notation": "off"
     // "@typescript-eslint/no-shadow": ["error"]
-=======
-    "react/react-in-jsx-scope": "off"
   },
   "settings": {
     "import/resolver": {
@@ -28,6 +25,5 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
->>>>>>> develop
   }
 }

--- a/moamoa/src/Pages/EditProfile.jsx
+++ b/moamoa/src/Pages/EditProfile.jsx
@@ -1,0 +1,133 @@
+/*
+  설명: 내 프로필 수정 페이지
+  작성자: 이해지
+  최초 작성 날짜: 2023.10.24
+  마지막 수정 날까: 
+*/
+
+import React, { useState } from 'react';
+
+function EditProfile({ handlePage }) {
+  const [username, setUsername] = useState('');
+  const [accountname, setAccountname] = useState('');
+  const [imgSrc, setImgSrc] = useState('https://api.mandarin.weniv.co.kr/Ellipse.png');
+  const [intro, setIntro] = useState('');
+
+  const edit = async (editData) => {
+    const reqUrl = 'https://api.mandarin.weniv.co.kr/user/';
+    const res = await fetch(reqUrl, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(editData),
+    });
+    const json = await res.json();
+    console.log(json);
+  };
+
+  const inputUsername = (e) => {
+    setUsername(e.target.value);
+  };
+  const inputAccountname = (e) => {
+    setAccountname(e.target.value);
+  };
+  const inputInfo = (e) => {
+    setIntro(e.target.value);
+  };
+
+  const uploadImage = async (imageFile) => {
+    const baseUrl = 'https://api.mandarin.weniv.co.kr/';
+    const reqUrl = baseUrl + 'image/uploadfile';
+    // 폼데이터 만들기
+    const form = new FormData();
+    // 폼데이터에 값 추가하기
+    // 폼데이터.append("키","값")
+    form.append('image', imageFile);
+    // 폼바디에 넣어서 요청하기
+    const res = await fetch(reqUrl, {
+      method: 'POST',
+      body: form,
+    });
+    const json = await res.json();
+    console.log(baseUrl + json.filename);
+    const imageUrl = baseUrl + json.filename;
+    setImgSrc(imageUrl);
+  };
+
+  const handleChangeImage = (e) => {
+    // 파일 가져오기
+    const imageFile = e.target.files[0];
+    uploadImage(imageFile);
+  };
+
+  const submitEdit = () => {
+    const editData = {
+      user: {
+        username: username,
+        accountname: accountname,
+        intro: intro,
+        image: imgSrc,
+      },
+    };
+    edit(editData);
+  };
+
+  return (
+    <>
+      <button type='button' onClick={handlePage}>
+        로그인페이지로 돌아가기
+      </button>
+      <section>
+        <h2>프로필 설정</h2>
+        <p>나중에 언제든지 변경할 수 있습니다.</p>
+        <label htmlFor='profileImg'>
+          <img src={imgSrc} alt='' id='imagePre' />
+        </label>
+        <input
+          type='file'
+          onChange={handleChangeImage}
+          id='profileImg'
+          name='image'
+          accept='image/*'
+        />
+        <div>
+          <label htmlFor='userNameInput'>사용자 이름</label>
+          <input
+            value={username}
+            onChange={inputUsername}
+            type='text'
+            id='userNameInput'
+            name='username'
+            placeholder='2~10자 이내여야 합니다.'
+          />
+        </div>
+        <div>
+          <label htmlFor='userIdInput'>계정 ID</label>
+          <input
+            value={accountname}
+            onChange={inputAccountname}
+            type='text'
+            id='userIdInput'
+            name='accountname'
+            placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
+          />
+        </div>
+        <div>
+          <label htmlFor='userIntroInput'>소개</label>
+          <input
+            onChange={inputInfo}
+            type='text'
+            id='userIntroInput'
+            name='intro'
+            placeholder='자신과 판매할 상품에 대해 소개해 주세요.'
+          />
+        </div>
+        <button type='button' onClick={submitEdit}>
+          감귤마켓 시작하기
+        </button>
+      </section>
+    </>
+  );
+}
+export default EditProfile;

--- a/moamoa/src/Pages/EditProfile.jsx
+++ b/moamoa/src/Pages/EditProfile.jsx
@@ -2,22 +2,68 @@
   설명: 내 프로필 수정 페이지
   작성자: 이해지
   최초 작성 날짜: 2023.10.24
-  마지막 수정 날까: 
+  마지막 수정 날까: 2023.10.24
 */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import userToken from '../Recoil/UserToken';
 
-function EditProfile({ handlePage }) {
-  const [username, setUsername] = useState('');
-  const [accountname, setAccountname] = useState('');
-  const [imgSrc, setImgSrc] = useState('https://api.mandarin.weniv.co.kr/Ellipse.png');
-  const [intro, setIntro] = useState('');
+function EditProfile() {
+  //기존 사용자의 정보를 가져오기
+  const token = useRecoilValue(userToken);
 
-  const edit = async (editData) => {
-    const reqUrl = 'https://api.mandarin.weniv.co.kr/user/';
-    const res = await fetch(reqUrl, {
-      method: 'POST',
+  const [initUsername, setInitUsername] = useState('');
+  const [initAccountname, setInitAccountname] = useState('');
+  const [initIntron, setInitIntron] = useState('');
+  const [initImgSrc, setInitImgSrc] = useState(''); // 이미 있는 이미지 주소
+
+  // 내 정보 API
+  const getInitInfo = async () => {
+    console.log(token);
+    const res = await fetch('https://api.mandarin.weniv.co.kr/user/myinfo', {
+      method: 'GET',
       headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const json = await res.json();
+    console.log(json);
+
+    if (json && json.user) {
+      setInitImgSrc(json.user['image'] || '');
+      setImgSrc(json.user['image'] || '');
+
+      setInitAccountname(json.user['accountname'] || '');
+      setAccountname(json.user['accountname'] || '');
+
+      setInitUsername(json.user['username'] || '');
+      setUsername(json.user['username'] || '');
+
+      setInitIntron(json.user['intro'] || '');
+      setIntro(json.user['intro'] || '');
+    }
+  };
+
+  useEffect(() => {
+    // 컴포넌트가 마운트될 때 getInitInfo 함수를 실행합니다.
+    getInitInfo();
+  }, []);
+
+  const [username, setUsername] = useState(initUsername);
+  const [accountname, setAccountname] = useState(initAccountname);
+  const [imgSrc, setImgSrc] = useState(initImgSrc);
+  const [intro, setIntro] = useState(initIntron);
+
+  // 프로필 수정 API
+  const edit = async (editData) => {
+    // const token = localStorage.getItem('token');
+
+    const reqUrl = 'https://api.mandarin.weniv.co.kr/user';
+    const res = await fetch(reqUrl, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
         'Content-type': 'application/json',
       },
       body: JSON.stringify(editData),
@@ -61,7 +107,9 @@ function EditProfile({ handlePage }) {
     uploadImage(imageFile);
   };
 
-  const submitEdit = () => {
+  const submitEdit = (e) => {
+    e.preventDefault();
+
     const editData = {
       user: {
         username: username,
@@ -75,14 +123,10 @@ function EditProfile({ handlePage }) {
 
   return (
     <>
-      <button type='button' onClick={handlePage}>
-        로그인페이지로 돌아가기
-      </button>
       <section>
-        <h2>프로필 설정</h2>
-        <p>나중에 언제든지 변경할 수 있습니다.</p>
+        <h1>내 프로필 수정</h1>
         <label htmlFor='profileImg'>
-          <img src={imgSrc} alt='' id='imagePre' />
+          <img src={imgSrc || initImgSrc} alt='Profile' id='imagePre' />
         </label>
         <input
           type='file'
@@ -99,7 +143,7 @@ function EditProfile({ handlePage }) {
             type='text'
             id='userNameInput'
             name='username'
-            placeholder='2~10자 이내여야 합니다.'
+            placeholder={initUsername ? `${initUsername}` : '2~10자 이내여야 합니다.'}
           />
         </div>
         <div>
@@ -110,21 +154,26 @@ function EditProfile({ handlePage }) {
             type='text'
             id='userIdInput'
             name='accountname'
-            placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
+            placeholder={
+              initAccountname
+                ? `${initAccountname}`
+                : '영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+            }
           />
         </div>
         <div>
           <label htmlFor='userIntroInput'>소개</label>
           <input
+            value={intro}
             onChange={inputInfo}
             type='text'
             id='userIntroInput'
             name='intro'
-            placeholder='자신과 판매할 상품에 대해 소개해 주세요.'
+            placeholder={initIntron ? `${initIntron}` : '자신과 판매할 상품에 대해 소개해 주세요!'}
           />
         </div>
         <button type='button' onClick={submitEdit}>
-          감귤마켓 시작하기
+          수정하기
         </button>
       </section>
     </>

--- a/moamoa/src/Pages/ProfileInfo.jsx
+++ b/moamoa/src/Pages/ProfileInfo.jsx
@@ -6,12 +6,14 @@
 */
 
 import React, { useState, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
+import userToken from '../Recoil/UserToken';
 
 function EventList() {
   const [eventList, setEventList] = useState([]);
+  const token = useRecoilValue(userToken);
 
   const getEventList = async () => {
-    const token = localStorage.getItem('token');
     const accountname = localStorage.getItem('accountname');
 
     const res = await fetch(`https://api.mandarin.weniv.co.kr/product/${accountname}`, {
@@ -61,8 +63,9 @@ function ProfileInfo() {
   const [profileFollowerCount, setProfileFollowerCount] = useState(0);
   const [profileFollowingCount, setProfileFollowingCount] = useState(0);
 
+  const token = useRecoilValue(userToken);
+
   const getYourinfo = async () => {
-    const token = localStorage.getItem('token');
     const accountname = localStorage.getItem('accountname');
 
     const res = await fetch(`https://api.mandarin.weniv.co.kr/profile/${accountname}`, {

--- a/moamoa/src/Pages/ProfileInfo.jsx
+++ b/moamoa/src/Pages/ProfileInfo.jsx
@@ -1,10 +1,14 @@
+/*
+  설명: 사용지 accountname의 프로필 페이지(남의 페이지)
+  작성자: 이해지
+  최초 작성 날짜: 2023.10.23
+  마지막 수정 날까: 
+*/
+
 import React, { useState, useEffect } from 'react';
 
 function EventList() {
-  // const [eventImgList, setEventImgList] = useState([]);
   const [eventList, setEventList] = useState([]);
-  // const [eventNameList, setEventNameList] = useState<string[]>([]);
-  // const [eventPeriodList, setEventPeriodList] = useState<string[]>([]);
 
   const getEventList = async () => {
     const token = localStorage.getItem('token');
@@ -18,24 +22,8 @@ function EventList() {
       },
     });
     const json = await res.json();
-    // console.log(json.product);
-    // console.log(json.product[0]['itemImage']);
 
     setEventList(json.product);
-
-    // const ImgList = [];
-    // for (let i = 0; i < json.product.length; i += 1) {
-    //   ImgList.push(json.product[i]['itemImage']);
-    // }
-
-    // setEventImgList([...ImgList]);
-
-    // setProfileImg(json.profile['image']);
-    // setProfileAccountname(JSON.stringify(json.profile['accountname']));
-    // setProfileUsername(JSON.stringify(json.profile['username']));
-    // setProfileIntro(JSON.stringify(json.profile['intro']));
-    // setProfileFollowerCount(JSON.stringify(json.profile['followerCount']));
-    // setProfileFollowingCount(JSON.stringify(json.profile['followingCount']));
   };
 
   useEffect(() => {
@@ -111,7 +99,7 @@ function ProfileInfo() {
           <p>닉네임: {profileUsername}</p>
           <p>계정 id: {profileAccountname}</p>
           <p>소개글: {profileIntro}</p>
-          <p>게시글 수: </p>
+          {/* <p>게시글 수: 행사</p>   */}
           <p>팔로워: {profileFollowerCount}</p>
           <p>팔로잉: {profileFollowingCount}</p>
           <button type='button'>상품 등록</button>

--- a/moamoa/src/Router/AppRoutes.js
+++ b/moamoa/src/Router/AppRoutes.js
@@ -18,6 +18,7 @@ export default function AppRoutes() {
 
       {/* 내 프로필 수정*/}
       <Route path='/profile/edit' element={<EditProfile />} />
+      {/* 공통파일 프로필 수정 경로추가 */}
 
       {/* 로그인 */}
       {/* <Route path='/login' element={<?? />} /> */}

--- a/moamoa/src/Router/AppRoutes.js
+++ b/moamoa/src/Router/AppRoutes.js
@@ -5,6 +5,7 @@ import AddProduct from '../Pages/AddProduct';
 import LoginPage from '../Pages/Login';
 import JoinPage from '../Pages/Join';
 import ProfileInfo from '../Pages/ProfileInfo';
+import EditProfile from '../Pages/EditProfile';
 // import Landing from '../Pages/Landing';
 
 export default function AppRoutes() {
@@ -14,6 +15,9 @@ export default function AppRoutes() {
 
       {/* 내 프로필 */}
       <Route path='/profile' element={<ProfileInfo />} />
+
+      {/* 내 프로필 수정*/}
+      <Route path='/profile/edit' element={<EditProfile />} />
 
       {/* 로그인 */}
       {/* <Route path='/login' element={<?? />} /> */}


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
- eslintrc.json : merge 실수를 하여 발생한 중복 코드를 삭제했습니다.
- AppRoutes.js :프로필 수정 페이지의 경로를 추가했습니다.
- ProfileInfo.jsx : 주석 수정, recoil 에서 userToken받아 왔습니다.
- EditProfile.jsx : 프로필 수정 페이지입니다(메인주제)

### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
- 프로필 수정 페이지로 들어왔을때 기존 프로필 정보를 사용자에게 보여주는 기능 추가
- placeholder를 기존 프로필의 정보로 변경(특이사항1)
- 정보를 입력 후 수정하기 버튼 클릭 시 사용자의 정보 업데이트


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/116999139/f2d2465a-e093-4dca-a1da-cc770b1868b4)




### PR 특이 사항
계획
- 파일선택 버튼 클릭 후 이미지를 선택하지 않고 닫았을 경우 발생하는 오류 수정
- placeholder의 수정이 필요할 경우 수정
- 레이아웃 배치


### 특이 사항 :
- placeholder를 기존 프로필의 정보가 아닌 피그마에서 작성된 placeholder를 사용하는것이 기본인것같아 고민이됩니다. 의견 부탁드리겠습니다.

Issue Number: #29
