### PR TITLE
[✨ Feature] 상품 리스트 구현 축제,체험 구분 렌더링 빼고 구현

### DIFF
--- a/moamoa/src/Components/Common/Container.jsx
+++ b/moamoa/src/Components/Common/Container.jsx
@@ -5,10 +5,10 @@ export const Container = styled.div`
   max-width: 390px;
   width: 100%;
   flex: 1;
-
+  height: 120vh;
   display: flex;
   flex-direction: column;
   position: relative;
-  /* border: 1px solid black; */
   background-color: #fff;
+  /* border: 1px solid black; */
 `;

--- a/moamoa/src/Components/Common/Footer.jsx
+++ b/moamoa/src/Components/Common/Footer.jsx
@@ -76,9 +76,10 @@ const TabMenu = styled.div`
   height: 60px;
   background-color: #2e2c39;
   display: flex;
-  margin-top: 87px;
   position: fixed;
   bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
 `;
 
 const TabButton = styled.button`

--- a/moamoa/src/GlobalStyle.jsx
+++ b/moamoa/src/GlobalStyle.jsx
@@ -10,8 +10,8 @@ html{
 	font-size: 62.5%;
 }
 body{
-	background-color:#fff9e4;
-	/* 여기에 color 주는건 별로일까요? */
+	/* background-color:#fff9e4; */
+	/* 바디에 배경색 */
 	font-family: 'Pretendard', sans-serif;
 }
 a{

--- a/moamoa/src/GlobalStyle.jsx
+++ b/moamoa/src/GlobalStyle.jsx
@@ -10,6 +10,8 @@ html{
 	font-size: 62.5%;
 }
 body{
+	background-color:#fff9e4;
+	/* 여기에 color 주는건 별로일까요? */
 	font-family: 'Pretendard', sans-serif;
 }
 a{

--- a/moamoa/src/Pages/Product/ProductList.jsx
+++ b/moamoa/src/Pages/Product/ProductList.jsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import React, { useEffect, useState } from 'react';
-import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { atom, useRecoilState, useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import ProductImgBox from '../../Components/Common/ProductImgBox';
@@ -44,99 +43,93 @@ export default function ProductList() {
 
     fetchData();
   }, [token, setProduct]);
-  // 행시기간 함수
-  function formatDateString(dateString) {
-    const year = toString.slice(2, 4);
-    const month = toString.slice(4, 6);
-    const day = toString.slice(6, 8);
-    return `${year}.${month}.${day}`;
-  }
+
   //   리턴
   return (
-    <BackColor className='body'>
-      <Container>
-        <Header />
-        <Nav>
-          <FestivalBtn isActive={isFestivalActive} onClick={toggleFestival}>
-            축제
-          </FestivalBtn>
-          <ExperienceBtn isActive={isExperienceActive} onClick={toggleExperience}>
-            체험
-          </ExperienceBtn>
-        </Nav>
-        {loading ? (
-          <p>Loading...</p>
-        ) : error ? (
-          <p>Error:{error.message}</p>
-        ) : (
-          <ProductContainer>
-            {isFestivalActive
-              ? product
-                  .filter((item) => {
-                    if (item.price.toString().length >= 16) {
-                      return true;
-                    }
-                    return false;
-                  })
-                  .map((item, index) => (
+    <Container>
+      <Header />
+      <Nav>
+        <FestivalBtn isActive={isFestivalActive} onClick={toggleFestival}>
+          축제
+        </FestivalBtn>
+        <ExperienceBtn isActive={isExperienceActive} onClick={toggleExperience}>
+          체험
+        </ExperienceBtn>
+      </Nav>
+      {loading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p>Error:{error.message}</p>
+      ) : (
+        <ProductContainer>
+          {isFestivalActive
+            ? product
+                .filter((item) => {
+                  if (item.price.toString().length >= 16) {
+                    return true;
+                  }
+                  return false;
+                })
+                .map((item, index) => (
+                  <ProductBox key={index}>
                     <Link to={`/product/detail/${item._id}`} key={index}>
-                      <ProductBox key={index}>
-                        <ProductImgBox src={item.itemImage} />
-                        <p className='itemName'>{item.itemName}</p>
-                        <p className='itemDate'>
-                          {'행사기간: ' +
-                            `${item.price.toString().slice(2, 4)}.${item.price
-                              .toString()
-                              .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
-                              .toString()
-                              .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
-                              .toString()
-                              .slice(14, 16)}`}
-                        </p>
-                      </ProductBox>
-                    </Link>
-                  ))
-              : null}
-            {/* {console.log('콘솔로그는 뭘까:', product)} */}
-            {/* {console.log('아이디찾기:', product[0]._id)} */}
-            {isExperienceActive
-              ? product
-                  .filter((item) => {
-                    if (item.price.toString().length >= 16) {
-                      return true;
-                    }
-                    return false;
-                  })
-                  .map((item, index) => (
-                    <ProductBox key={index}>
                       <ProductImgBox src={item.itemImage} />
-                      <Link to={`/product/detail/${item._id}`} key={index}></Link>
-                      <p className='itemName'>{item.itemName}</p>
-                      <p className='itemDate'>
-                        {'행사기간: ' +
-                          `${item.price.toString().slice(2, 4)}.${item.price
-                            .toString()
-                            .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
-                            .toString()
-                            .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
-                            .toString()
-                            .slice(14, 16)}`}
-                      </p>
-                    </ProductBox>
-                  ))
-              : null}
-          </ProductContainer>
-        )}
-        <Footer></Footer>
-      </Container>
-    </BackColor>
+                    </Link>
+                    <p className='itemName'>{item.itemName}</p>
+                    <p className='itemDate'>
+                      {'행사기간: ' +
+                        `${item.price.toString().slice(2, 4)}.${item.price
+                          .toString()
+                          .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
+                          .toString()
+                          .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
+                          .toString()
+                          .slice(14, 16)}`}
+                    </p>
+                  </ProductBox>
+                ))
+            : null}
+          {console.log('콘솔로그는 뭘까:', product)}
+          {/* {console.log('아이디찾기:', product[0]._id)} */}
+          {isExperienceActive
+            ? product
+                .filter((item) => {
+                  if (item.price.toString().length >= 26) {
+                    return true;
+                  }
+                  return false;
+                })
+                .map((item, index) => (
+                  <ProductBox key={index}>
+                    <Link to={`/product/detail/${item._id}`} key={index}>
+                      <ProductImgBox src={item.itemImage} />
+                    </Link>
+                    <p className='itemName'>{item.itemName}</p>
+                    <p className='itemDate'>
+                      {'행사기간: ' +
+                        `${item.price.toString().slice(2, 4)}.${item.price
+                          .toString()
+                          .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
+                          .toString()
+                          .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
+                          .toString()
+                          .slice(14, 16)}`}
+                    </p>
+                  </ProductBox>
+                ))
+            : null}
+        </ProductContainer>
+      )}
+      <Footer></Footer>
+    </Container>
   );
 }
 
 const Nav = styled.div`
-  display: flex;
+  /* display: flex; */
   padding-top: 70px;
   padding-left: 10px;
+  /* height: 100vh; */
 `;
 const Button = styled.button`
   width: 80px;
@@ -167,7 +160,8 @@ const ProductContainer = styled.div`
   padding-bottom: 150px;
   background-image: url(${backgroundMoamoa});
   background-repeat: no-repeat;
-  background-position: 110% 88%;
+  background-position: 110% 91%;
+  height: 100%;
 `;
 const ProductBox = styled.div`
   max-width: 172px;
@@ -177,16 +171,11 @@ const ProductBox = styled.div`
     font-size: 14px;
     margin: 12px 0 6px 4px;
     font-weight: 500;
-    cursor: default;
   }
   .itemDate {
     margin-left: 4px;
     color: #797979;
     font-size: 11px;
     font-weight: 400;
-    cursor: default;
   }
-`;
-const BackColor = styled.div`
-  background-color: #fff9e4;
 `;


### PR DESCRIPTION

<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
바디의 배경색은 앞으로 모든 




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
feat: 상품 리스트의 스타일,상세페이지 이동 구현하였고 축제와 체험 구분 렌더링은 
아직 구현하지 못했습니다.
다른 기능 상세페이지 이동, 행시기간 price 를 string으로 다시 바꿔 
ex)행사기간: 23.10.10~23.10.15 로 구현했습니다.




### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->

![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/fb32a14a-3230-41ab-9ba6-a1fcf6e55f25)
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/b5c2ab8b-f9c6-4962-9575-7a46cd8c30a6)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
상세페이지 넘어가는 부분과 상품리스트의 정상출력에 문제가 생기면 말씀 부탁드립니다!



### 특이 사항 :
Issue Number #22 

close: # 자기가 개발 전에 올린 이슈
