### PR TITLE
[🔧 Fix] 회원가입 시 회원유형 선택 / 상품등록 시 행사유형 선택 기능 수정

### DIFF
--- a/moamoa/src/API/Auth/JoinAPI.jsx
+++ b/moamoa/src/API/Auth/JoinAPI.jsx
@@ -1,4 +1,4 @@
-const JoinAPI = async (userInfo) => {
+const JoinAPI = async (userInfo, userType) => {
   const reqUrl = 'https://api.mandarin.weniv.co.kr/user';
 
   try {
@@ -7,7 +7,16 @@ const JoinAPI = async (userInfo) => {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ ...userInfo }),
+      body: JSON.stringify({
+        ...userInfo,
+        user: {
+          ...userInfo.user,
+          username:
+            userType === 'individual'
+              ? `[i]${userInfo.user.username}`
+              : `[o]${userInfo.user.username}`,
+        },
+      }),
     });
     const result = await response.json();
     console.log(result);

--- a/moamoa/src/API/Product/ProductUploadAPI.jsx
+++ b/moamoa/src/API/Product/ProductUploadAPI.jsx
@@ -1,17 +1,11 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import axios from 'axios';
 import userTokenAtom from '../../Recoil/userTokenAtom';
-import eventTypeAtom from '../../Recoil/eventTypeAtom';
 
 const ProductUploadAPI = (inputValue) => {
   const reqURL = 'https://api.mandarin.weniv.co.kr/product';
   const token = useRecoilValue(userTokenAtom);
   const { eventName, eventPeriod, eventDetail, imgSrc, eventType } = inputValue;
-
-  const setEventTypeAtom = useSetRecoilState(eventTypeAtom);
-  const saveEventType = () => {
-    setEventTypeAtom({ eventType, eventName });
-  };
 
   const uploadProduct = async () => {
     try {
@@ -23,14 +17,13 @@ const ProductUploadAPI = (inputValue) => {
         },
         data: {
           product: {
-            itemName: eventName,
+            itemName: eventType === 'festival' ? `[f]${eventName}` : `[e]${eventName}`,
             price: eventPeriod,
             link: eventDetail,
             itemImage: imgSrc,
           },
         },
       }).then((res) => {
-        saveEventType();
         console.log(res.data);
       });
     } catch (error) {

--- a/moamoa/src/Hooks/Sign/useJoin.jsx
+++ b/moamoa/src/Hooks/Sign/useJoin.jsx
@@ -2,8 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import JoinAPI from '../../API/Auth/JoinAPI';
 import EmailValidAPI from '../../API/Valid/EmailValidAPI';
-import { useSetRecoilState } from 'recoil';
-import userTypeAtom from '../../Recoil/userTypeAtom';
 
 const useJoin = () => {
   const navigate = useNavigate();
@@ -23,8 +21,6 @@ const useJoin = () => {
       image: '',
     },
   });
-
-  const setUserTypeAtom = useSetRecoilState(userTypeAtom);
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -73,13 +69,12 @@ const useJoin = () => {
   };
 
   const handleJoin = async () => {
-    const res = await JoinAPI(userInfo);
+    const res = await JoinAPI(userInfo, userType);
 
     if (res) {
       setErrorMessage(res.message);
 
       if (res.message === '회원가입 성공') {
-        setUserTypeAtom(userType);
         navigate('/user/login');
       }
     }


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 판매자 계정으로 회원가입 => 개인 계정으로 회원가입 => 기존 가입한 판매자로 로그인 시 userTypeAtom(판매자가 아닌 개인으로 출력)이 지속되지 않는 문제 발생했습니다.
+ 상품 등록도 유사한 문제가 발생했습니다. (축제/체험)




### 작업 내역
+ 회원 가입 시 사용자가 선택한 회원 유형에 따라 사용자 명 앞에 구분 문자를 넣었습니다.   
   + 개인: [i]사용자 명
   + 기업 및 기관: [o]사용자 명

+ 상품 등록 시 사용자가 선택한 행사 유형에 따라 상품 명 앞에 구분 문자를 넣었습니다.
   + 축제: [f]상품 명
   + 체험: [e]상품 명




### 작업 후 기대 동작(스크린샷) 
![Fix 회원가입](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/c66d7969-10c7-4db8-bc2b-36b70043742a)

![Fix 상품등록](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/6fae4798-4810-40be-b64c-ce5935a5754a)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number

close: # 98
