### PR TITLE
[✨feature] 상품 리스트 축제와 체험 나눠 출력 구현

### DIFF
--- a/moamoa/src/GlobalStyle.jsx
+++ b/moamoa/src/GlobalStyle.jsx
@@ -10,7 +10,7 @@ html{
 	font-size: 62.5%;
 }
 body{
-	/* background-color:#fff9e4; */
+	background-color:#fff9e4;
 	/* 바디에 배경색 */
 	font-family: 'Pretendard', sans-serif;
 }

--- a/moamoa/src/Pages/Product/ProductList.jsx
+++ b/moamoa/src/Pages/Product/ProductList.jsx
@@ -64,18 +64,22 @@ export default function ProductList() {
         <ProductContainer>
           {isFestivalActive
             ? product
+
                 .filter((item) => {
                   if (item.price.toString().length >= 16) {
                     return true;
                   }
                   return false;
                 })
+                .filter((item) => {
+                  return item.itemName.includes('[f]');
+                })
                 .map((item, index) => (
                   <ProductBox key={index}>
                     <Link to={`/product/detail/${item._id}`} key={index}>
                       <ProductImgBox src={item.itemImage} />
                     </Link>
-                    <p className='itemName'>{item.itemName}</p>
+                    <p className='itemName'>{item.itemName.replace('[f]', '')}</p>
                     <p className='itemDate'>
                       {'행사기간: ' +
                         `${item.price.toString().slice(2, 4)}.${item.price
@@ -94,17 +98,20 @@ export default function ProductList() {
           {isExperienceActive
             ? product
                 .filter((item) => {
-                  if (item.price.toString().length >= 26) {
+                  if (item.price.toString().length >= 16) {
                     return true;
                   }
                   return false;
+                })
+                .filter((item) => {
+                  return item.itemName.includes('[e]');
                 })
                 .map((item, index) => (
                   <ProductBox key={index}>
                     <Link to={`/product/detail/${item._id}`} key={index}>
                       <ProductImgBox src={item.itemImage} />
                     </Link>
-                    <p className='itemName'>{item.itemName}</p>
+                    <p className='itemName'>{item.itemName.replace('[e]', '')}</p>
                     <p className='itemDate'>
                       {'행사기간: ' +
                         `${item.price.toString().slice(2, 4)}.${item.price
@@ -162,6 +169,7 @@ const ProductContainer = styled.div`
   background-repeat: no-repeat;
   background-position: 110% 91%;
   height: 100%;
+  grid-template-rows: 160px;
 `;
 const ProductBox = styled.div`
   max-width: 172px;


### PR DESCRIPTION


<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
전에는 축제와 체험을 구분하지 못했습니다. 그래서 상품 등록 페이지에서 축제와 체험을 구분하는 버튼을 클릭하였을 때 상품의 앞에 [f] 또는 [e]가 포함되어 필터링 할 수 있도록 상품 등록을 맡은 팀원이 구현하였습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
상품 리스트의 제목에 붙은 [f]와 [e]를 이용해 카테고리를 나눠 렌더링 하였고,  [f]와[e]에 replace를
이용해 제거하여 렌더링 하였습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/01451141-84a6-4593-85b4-c41d11a46b50)
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/3d09edd1-70eb-404d-a8bf-7a42bf9d9553)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
이제 상품 리스트에서 고민해야 할 일은 상품을 10개밖에 가져오지 못하는 점과 다른 상품들과 겹쳐서 불러왔을 때 우리 상품이 적게 출력 되거나 또는 아예 안 보이는 점을 고민해야 할 것 같습니다.



### 특이 사항 :
Issue Number #22 

close: # 자기가 개발 전에 올린 이슈
