### PR TITLE
[🔧fix]  Splash 화면에서 콘솔에 나오는 오류

### DIFF
--- a/moamoa/src/Pages/Splash/Landing.jsx
+++ b/moamoa/src/Pages/Splash/Landing.jsx
@@ -30,7 +30,7 @@ export default function Landing() {
           <p className='logotext'>내 손 안의 안의 모든 축제!</p>
         </SVGgroup>
         <Copyright>@copyright moamoa corp</Copyright>
-        <LoginModal visible={modalActive ? 'true' : 'false'}>
+        <LoginModal visible={modalActive ? true : false}>
           <Link to='/user/login'>
             <BlueMoa>이메일 계정으로 로그인</BlueMoa>
           </Link>
@@ -132,8 +132,8 @@ const LoginModal = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== 'visible',
 })`
   position: fixed;
-  bottom: ${(props) => (props.visible === 'true' ? '0' : '-300px')};
-  visibility: ${(props) => (props.visible === 'true' ? 'visible' : 'hidden')};
+  bottom: ${(props) => (props.visible === true ? '0' : '-300px')};
+  visibility: ${(props) => (props.visible === true ? 'visible' : 'hidden')};
   transition: 0.5s ease;
   display: flex;
   flex-direction: column;

--- a/moamoa/src/Pages/Splash/Landing.jsx
+++ b/moamoa/src/Pages/Splash/Landing.jsx
@@ -12,12 +12,9 @@ import { Link } from 'react-router-dom';
 export default function Landing() {
   const [modalActive, setModalActive] = useState(false);
   useEffect(() => {
-    // 3초 뒤에 모달을 자동으로 활성화하도록 설정합니다.
     const modalTimeout = setTimeout(() => {
       setModalActive(true);
     }, 2000);
-
-    // 컴포넌트가 언마운트되면 타임아웃을 클리어합니다.
     return () => clearTimeout(modalTimeout);
   }, []);
 
@@ -33,7 +30,7 @@ export default function Landing() {
           <p className='logotext'>내 손 안의 안의 모든 축제!</p>
         </SVGgroup>
         <Copyright>@copyright moamoa corp</Copyright>
-        <LoginModal visible={modalActive}>
+        <LoginModal visible={modalActive ? 'true' : 'false'}>
           <Link to='/user/login'>
             <BlueMoa>이메일 계정으로 로그인</BlueMoa>
           </Link>
@@ -97,31 +94,31 @@ const SVGgroup = styled.div`
   }
   @keyframes blink {
     0% {
-      opacity: 0.2; /* 초기에 투명 */
+      opacity: 0.2;
     }
     10% {
-      opacity: 0.1; /* 초기에 투명 */
+      opacity: 0.1;
     }
     20% {
-      opacity: 0.2; /* 초기에 투명 */
+      opacity: 0.2;
     }
     30% {
-      opacity: 0.15; /* 초기에 투명 */
+      opacity: 0.15;
     }
     32% {
-      opacity: 0.8; /* 초기에 투명 */
+      opacity: 0.8;
     }
     50% {
-      opacity: 0.1; /* 50% 지점에서 불투명 */
+      opacity: 0.1;
     }
     70% {
-      opacity: 0.04; /* 50% 지점에서 불투명 */
+      opacity: 0.04;
     }
     85% {
-      opacity: 0.1; /* 50% 지점에서 불투명 */
+      opacity: 0.1;
     }
     100% {
-      opacity: 1; /* 100% 지점에서 다시 투명 */
+      opacity: 1;
     }
   }
 `;
@@ -131,10 +128,12 @@ const Copyright = styled.p`
   color: #ffffff;
   font-size: 14px;
 `;
-const LoginModal = styled.div`
+const LoginModal = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== 'visible',
+})`
   position: fixed;
-  bottom: ${(props) => (props.visible ? '0' : '-300px')};
-  visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
+  bottom: ${(props) => (props.visible === 'true' ? '0' : '-300px')};
+  visibility: ${(props) => (props.visible === 'true' ? 'visible' : 'hidden')};
   transition: 0.5s ease;
   display: flex;
   flex-direction: column;
@@ -160,7 +159,7 @@ const LoginModal = styled.div`
   }
 `;
 
-const tempLoginButton = styled.button`
+const TempLoginButton = styled.button`
   margin: 0 auto;
   width: 322px;
   height: 44px;
@@ -170,25 +169,25 @@ const tempLoginButton = styled.button`
   cursor: pointer;
   background-repeat: no-repeat;
 `;
-const BlueMoa = styled(tempLoginButton)`
+const BlueMoa = styled(TempLoginButton)`
   border: 1px solid #017dc2;
   background-image: url(${Bluemoa});
   background-size: 30px;
   background-position: 14px 2px;
 `;
-const Kakao = styled(tempLoginButton)`
+const Kakao = styled(TempLoginButton)`
   border: 1px solid #f0e2b9;
   background-image: url(${kakao});
   background-size: 24px;
   background-position: 16px 9px;
 `;
-const Google = styled(tempLoginButton)`
+const Google = styled(TempLoginButton)`
   border: 1px solid #888282;
   background-image: url(${google});
   background-size: 30px;
   background-position: 14px 6px;
 `;
-const Naver = styled(tempLoginButton)`
+const Naver = styled(TempLoginButton)`
   border: 1px solid #a1e9a0;
   background-image: url(${naver});
   background-size: 30px;


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
콘솔로그의 오류가 스플래쉬 화면에서 계속 발견되었습니다.
동작은 이상이 없었습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
<LoginModal visible={modalActive}> -> 수정 전 
 <LoginModal visible={modalActive ? true :false}> -> 수정 후
DOM에서 prop은 유효한 속성이 아니므로 경고를 주었습니다.

const LoginModal = styled.div` -> 수정 전 
const LoginModal = styled.div.withConfig({     -> 수정 후
  shouldForwardProp: (prop) => prop !== 'visible',
})
visible prop의 값을 true와 false가 전달 되도록 수정하였고 , 
shouldForwardProp 함수는 컴포넌트로 전달된 prop 중에서 실제 DOM 엘리먼트에 전달할 것인지 여부를 결정하는 함수입니다. 이 함수를 통해 원하는 prop을 전달하고, 다른 prop을 필터링하여 DOM에 전달하지 않을 수 있습니다.

그러므로 DOM에 prop이 필터링 되기 때문에 <LoginModal visible={modalActive}> -> 수정 전 
 <LoginModal visible={modalActive ? 'true' : 'false'}> -> 수정 후 는 수정 전으로 바꾸어도 오류는 나지 않습니다



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/96eee195-3e69-454d-ad03-2d814feb605b)

![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/c3d85e51-4451-4ee0-9482-949147581008)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
styled-components는 컴포넌트에 전달된 모든 prop을 DOM 엘리먼트로 전달합니다 이 때 브라우저에서 인식하지 못하는 prop이 포함되면서 React에서 경고나 오류가 발생합니다. 그래서 withConfig 함수와 shouldForwardProp 함수를 사용하여 prop을 필터링하여 불필요한 prop 전달을 막았습니다.
DOM에게 prop은 생소한 속성인 것으로 보입니다.




### 특이 사항 :
Issue Number #105 

close: # 자기가 개발 전에 올린 이슈
