### PR TITLE
[✨Feature] 스플래시 페이지 로그인 상태 유/무 예외처리 구현

### DIFF
--- a/moamoa/src/Pages/Splash/Landing.jsx
+++ b/moamoa/src/Pages/Splash/Landing.jsx
@@ -7,9 +7,13 @@ import google from '../../Assets/images/google.png';
 import naver from '../../Assets/images/naver.png';
 import fireworks from '../../Assets/images/fireworks.svg';
 import Festival from '../../Assets/images/Festival.svg';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
+import userTokenAtom from '../../Recoil/userTokenAtom';
+import { useRecoilValue } from 'recoil';
 
 export default function Landing() {
+  const navigate = useNavigate();
+  const userToken = useRecoilValue(userTokenAtom);
   const [modalActive, setModalActive] = useState(false);
   useEffect(() => {
     // 3초 뒤에 모달을 자동으로 활성화하도록 설정합니다.
@@ -21,6 +25,13 @@ export default function Landing() {
     return () => clearTimeout(modalTimeout);
   }, []);
 
+  useEffect(() => {
+    if (userToken) {
+      navigate('/home');
+    } else {
+      navigate('/');
+    }
+  });
   return (
     <Container>
       <MoaMoaBox>
@@ -41,7 +52,9 @@ export default function Landing() {
           <Google>구글 계정으로 로그인</Google>
           <Naver>네이버 계정으로 로그인</Naver>
           <p>아직 회원이 아니신가요?</p>
-          <a href='#'>이메일로 회원가입</a>
+          <Link to='/user/join'>
+            <a href='#'>이메일로 회원가입</a>
+          </Link>
         </LoginModal>
       </MoaMoaBox>
     </Container>
@@ -88,7 +101,6 @@ const SVGgroup = styled.div`
   .blinkfireworks {
     transform: translateX(95%);
     justify-content: center;
-
     width: 57px;
     height: 57px;
   }


### PR DESCRIPTION
스플래시 창에서 조건문으로 토큰을 가지고 있다면 바로 홈으로 , 토큰이 없다면 스플래시 화면으로 이동하는 기능을 구현하였습니다.

<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
모아모아에 접속하면 이미 로그인 했어도 스플래시 화면을 보아야하는 점을 토큰을 가지고 있으면 접속했을 때 스플래시 화면이 아닌 바로 홈 화면으로 이동하는 기능을 구현하였습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
기능 구현 코드를 작성하고 제 토큰을 지우고 테스트를 해보았습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
토큰을 가지고 있는 상태이고 주소창에 스플래시 화면으로 가는 링크를 적어놓고 엔터를 치지 않았습니다.
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/9bfee153-597f-4f6a-be70-215d3447569f)
엔터를 쳐서 스플래시 화면으로 이동하려고 했고 바로 홈화면으로 이동되었습니다.
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/521cc564-5d48-497e-ac7d-cb3476730d61)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #109 

close: # 자기가 개발 전에 올린 이슈
