### PR TITLE
[✨ Feature] 사용자 프로필로 이동 기능 추가

### DIFF
--- a/moamoa/src/Components/Common/PostCardUser.jsx
+++ b/moamoa/src/Components/Common/PostCardUser.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 PostCardUser.propTypes = {
   url: PropTypes.string,
@@ -12,13 +13,15 @@ export default function PostCardUser({url, username, accountname }) {
   return (
     <Container>
         <>
-          <UserInfo>
-            <FrofileImg src={url} alt="사용자프로필"/>        
-            <InfoText>
-              <UserName>{username}</UserName>
-              <AccountName>@{accountname}</AccountName>
-            </InfoText>
-          </UserInfo>
+          <Link to={`/profile/${accountname}`}>
+            <UserInfo>
+              <FrofileImg src={url} alt="사용자프로필"/>        
+              <InfoText>
+                <UserName>{username}</UserName>
+                <AccountName>@{accountname}</AccountName>
+              </InfoText>
+            </UserInfo>
+          </Link>
         </>
     </Container>
   )


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
게시글 사용자 정보 클릭시 사용자 프로필로 이동하도록 기능 추가 했습니다!



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
<img width="424" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/e8ff85a1-dc31-49cd-b9ed-4cbcaa5e1987">


▼▼▼▼  클릭시 이동  ▼▼▼▼
<img width="289" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/b295819c-e9f5-4b18-89ce-d7db36bc9160">




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number

close: #113 
