### PR TITLE
[🌈 Style] 게시글 수정 페이지 스타일 적용

### DIFF
--- a/moamoa/src/Pages/Post/EditPost.jsx
+++ b/moamoa/src/Pages/Post/EditPost.jsx
@@ -10,6 +10,24 @@ import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import userToken from '../../Recoil/userTokenAtom';
 
+import { Container } from '../../Components/Common/Container';
+import Gobackbtn from '../../Components/Common/GoBackbtn';
+import ButtonSubmit from '../../Components/Common/Button';
+
+import uploadFile from '../../Assets/images/upload-file.png';
+import xButton from '../../Assets/icons/x.svg';
+
+import {
+  HeaderContainer,
+  HiddenH1,
+  UploadPostBox,
+  ProfileImg,
+  TextArea,
+  ImgPre,
+  XButton,
+  InputImgIcon,
+} from './UloadEditPostStyle';
+
 export default function EditPost() {
   const token = useRecoilValue(userToken);
   const navigate = useNavigate();
@@ -35,6 +53,11 @@ export default function EditPost() {
       const postContent = json.post['content'] || '';
       setContent(postContent);
       console.log(postContent);
+
+      const textarea = document.getElementById('contentTextarea');
+      if (textarea) {
+        adjustTextareaHeight({ target: textarea });
+      }
 
       const postImage = json.post['image'] || '';
       setImage(postImage);
@@ -95,6 +118,15 @@ export default function EditPost() {
     uploadImage(imageFile);
   };
 
+  //textarea 높이 설정
+  const adjustTextareaHeight = (event) => {
+    const textarea = event.target;
+    // 높이 초기화
+    textarea.style.height = 'auto';
+    // 스크롤 높이만큼 textarea 높이 설정
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  };
+
   const inputContent = (e) => {
     setContent(e.target.value);
   };
@@ -113,6 +145,7 @@ export default function EditPost() {
 
   const closeImg = () => {
     setImage('');
+    document.getElementById('profileImg').value = ''; // 파일 인풋 초기화
   };
 
   useEffect(() => {
@@ -129,44 +162,69 @@ export default function EditPost() {
   };
 
   return (
-    <section>
-      <h1>게시글 등록</h1>
-      {/* 사용자 프로필 */}
-      <form onSubmit={handleFormSubmit}>
-        <img src={userImage} alt='post' id='imagePre' />
+    <Container>
+      <HeaderContainer>
+        <Gobackbtn />
+        <ButtonSubmit buttonText='저장' onClickHandler={submitEdit} disabled={isButtonDisabled} />
+      </HeaderContainer>
+      <UploadPostBox>
+        <section>
+          <HiddenH1>
+            <h1>게시글 수정</h1>
+          </HiddenH1>
+          <form onSubmit={handleFormSubmit}>
+            <ProfileImg>
+              {/* 사용자 프로필 */}
+              <img src={userImage} alt='post' id='imagePre' />
+            </ProfileImg>
+            <TextArea>
+              <div>
+                {/* 내용 입력 창 */}
+                <textarea
+                  value={content}
+                  onChange={(e) => {
+                    inputContent(e);
+                    adjustTextareaHeight(e);
+                  }}
+                  id='contentTextarea'
+                  name='content'
+                  rows='1'
+                  cols='50'
+                  placeholder='내용을 입력해주세요'
+                ></textarea>
+              </div>
+            </TextArea>
 
-        {/* 게시글 이미지 */}
-        <button type='button' onClick={closeImg}>
-          닫기
-        </button>
-        <div>
-          <label htmlFor='profileImg'>
-            <img src={image} alt='' id='imagePre' />
-          </label>
-          <input
-            type='file'
-            onChange={handleChangeImage}
-            id='profileImg'
-            name='image'
-            accept='image/*'
-          />
-        </div>
-        <div>
-          {/* 내용 입력 창 */}
-          <textarea
-            value={content}
-            onChange={inputContent}
-            id='contentTextarea'
-            name='content'
-            rows='10'
-            cols='50'
-            placeholder='내용을 입력해주세요'
-          ></textarea>
-        </div>
-        <button type='button' onClick={submitEdit} disabled={isButtonDisabled}>
-          게시글 등록
-        </button>
-      </form>
-    </section>
+            <div>
+              {/* 이미지 미리보기 */}
+              {image ? (
+                <ImgPre>
+                  <img src={image} alt='' id='imagePre' />
+                  <XButton>
+                    <button type='button' onClick={closeImg}>
+                      <img src={xButton} alt='' />
+                    </button>
+                  </XButton>
+                </ImgPre>
+              ) : null}
+              {/* 이미지 등록 버튼 */}
+              <InputImgIcon>
+                <label htmlFor='profileImg'>
+                  <img src={uploadFile} alt='' />
+                </label>
+                <input
+                  type='file'
+                  onChange={handleChangeImage}
+                  id='profileImg'
+                  name='image'
+                  accept='image/*'
+                  style={{ display: 'none' }}
+                />
+              </InputImgIcon>
+            </div>
+          </form>
+        </section>
+      </UploadPostBox>
+    </Container>
   );
 }

--- a/moamoa/src/Pages/Post/UloadEditPostStyle.jsx
+++ b/moamoa/src/Pages/Post/UloadEditPostStyle.jsx
@@ -1,0 +1,107 @@
+import styled from 'styled-components';
+
+export const HeaderContainer = styled.header`
+  display: flex;
+  height: 55px;
+  width: 390px;
+  justify-content: space-between;
+  border-bottom: 2px solid #dbdbdb;
+  background-color: #fff;
+  align-items: center;
+  font-size: 24px;
+  font-weight: bold;
+  padding-left: 10px;
+  padding-right: 10px;
+  box-sizing: border-box;
+
+  img {
+    cursor: pointer;
+  }
+`;
+
+export const a11yHidden = `
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  width: 1px
+	height: 1px;
+	margin: -1px;
+  overflow: hidden;
+	padding: 0;
+	position: absolute;
+`;
+
+export const HiddenH1 = styled.h1`
+  ${a11yHidden}
+`;
+
+export const UploadPostBox = styled.div`
+  flex: 1;
+  padding: 16px;
+  position: relative;
+`;
+
+export const ProfileImg = styled.div`
+  width: 42px;
+  height: 42px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%; // 원형으로 보이게 하려면 추가
+  }
+`;
+
+export const TextArea = styled.div`
+  padding: 10px 0;
+
+  textarea {
+    resize: none; // 이 부분을 추가합니다.
+    box-sizing: border-box;
+    width: 100%;
+    border-radius: 2px;
+    padding-top: 5px; // 위쪽 padding 추가
+    padding-left: 5px; // 왼쪽 padding 추가
+    overflow-y: hidden;
+
+    border: none;
+
+    &:focus {
+      border: 1px solid #ffc700; // textarea가 포커스될 때 빨간색 테두리가 생깁니다.
+      outline: none; // 기본 브라우저 포커스 스타일을 제거합니다.
+    }
+  }
+`;
+
+export const ImgPre = styled.div`
+  height: 228px;
+  position: relative;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 10px;
+  }
+`;
+
+export const XButton = styled.div`
+  position: absolute;
+  top: 6px;
+  right: 6px;
+`;
+
+export const InputImgIcon = styled.div`
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+
+  width: 50px;
+  height: 50px;
+
+  img {
+    width: 100%;
+    height: 100%;
+
+    cursor: pointer;
+  }
+`;

--- a/moamoa/src/Pages/Post/UploadPost.jsx
+++ b/moamoa/src/Pages/Post/UploadPost.jsx
@@ -2,7 +2,7 @@
   설명: 게시글 등록 페이지
   작성자: 이해지
   최초 작성 날짜: 2023.10.24
-  마지막 수정 날까: 2023.10.30
+  마지막 수정 날까: 2023.10.31
 */
 
 import React, { useState, useEffect } from 'react';
@@ -10,13 +10,22 @@ import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 
 import userToken from '../../Recoil/userTokenAtom'; ////파일 경로 변경 완료
-import styled from 'styled-components';
 import { Container } from '../../Components/Common/Container';
 import Gobackbtn from '../../Components/Common/GoBackbtn';
 import ButtonSubmit from '../../Components/Common/Button';
 
 import uploadFile from '../../Assets/images/upload-file.png';
 import xButton from '../../Assets/icons/x.svg';
+import {
+  HeaderContainer,
+  HiddenH1,
+  UploadPostBox,
+  ProfileImg,
+  TextArea,
+  ImgPre,
+  XButton,
+  InputImgIcon,
+} from './UloadEditPostStyle';
 
 export default function AddPost() {
   const token = useRecoilValue(userToken);
@@ -207,108 +216,3 @@ export default function AddPost() {
     </Container>
   );
 }
-const HeaderContainer = styled.header`
-  display: flex;
-  height: 55px;
-  width: 390px;
-  justify-content: space-between;
-  border-bottom: 2px solid #dbdbdb;
-  background-color: #fff;
-  align-items: center;
-  font-size: 24px;
-  font-weight: bold;
-  padding-left: 10px;
-  padding-right: 10px;
-  box-sizing: border-box;
-
-  img {
-    cursor: pointer;
-  }
-`;
-
-const a11yHidden = `
-  clip: rect(1px, 1px, 1px, 1px);
-  clip-path: inset(50%);
-  width: 1px
-	height: 1px;
-	margin: -1px;
-  overflow: hidden;
-	padding: 0;
-	position: absolute;
-`;
-
-const HiddenH1 = styled.h1`
-  ${a11yHidden}
-`;
-
-const UploadPostBox = styled.div`
-  flex: 1;
-  padding: 16px;
-  position: relative;
-`;
-
-const ProfileImg = styled.div`
-  width: 42px;
-  height: 42px;
-
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 50%; // 원형으로 보이게 하려면 추가
-  }
-`;
-
-const TextArea = styled.div`
-  padding: 10px 0;
-
-  textarea {
-    resize: none; // 이 부분을 추가합니다.
-    box-sizing: border-box;
-    width: 100%;
-    border-radius: 2px;
-    padding-top: 5px; // 위쪽 padding 추가
-    padding-left: 5px; // 왼쪽 padding 추가
-    overflow-y: hidden;
-
-    border: none;
-
-    &:focus {
-      border: 1px solid #ffc700; // textarea가 포커스될 때 빨간색 테두리가 생깁니다.
-      outline: none; // 기본 브라우저 포커스 스타일을 제거합니다.
-    }
-  }
-`;
-
-const ImgPre = styled.div`
-  height: 228px;
-  position: relative;
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 10px;
-  }
-`;
-
-const XButton = styled.div`
-  position: absolute;
-  top: 6px;
-  right: 6px;
-`;
-
-const InputImgIcon = styled.div`
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-
-  width: 50px;
-  height: 50px;
-
-  img {
-    width: 100%;
-    height: 100%;
-
-    cursor: pointer;
-  }
-`;


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
- UloadEditPostStyle.jsx : UploadPost페이지와 EditPost페이지의 공통 스타일 컴포넌트를 모아둔 파일


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
- 게시글 업로드 페이지와 스타일이 동일하기에 공통 스타일 컴포넌트를 분리한 파일을 만들어 활용했습니다.
- 게시글 업로드 페이지와 기능은 동일하며 textarea에 focus가 올 시 테두리색이 변화합니다.
- textarea의 content 길이에 따라 textarea의 줄 수가 변화합니다.

### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/116999139/0d4e7c67-a738-4dd8-bb8d-2051cdb1572e)


### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
계획
- 프로필 상세 페이지 스타일 적용
- 프로필 수정 페이지 스타일 적용

### 특이 사항 :
Issue Number #129 
