### PR TITLE
[✨ Feature] 상품 삭제 기능 구현

### DIFF
--- a/moamoa/src/API/Product/ProductDeleteAPI.jsx
+++ b/moamoa/src/API/Product/ProductDeleteAPI.jsx
@@ -1,0 +1,36 @@
+import { useRecoilValue } from 'recoil';
+import userTokenAtom from '../../Recoil/userTokenAtom';
+
+const ProductDeleteAPI = (params) => {
+  const reqURL = 'https://api.mandarin.weniv.co.kr';
+  const token = useRecoilValue(userTokenAtom);
+  const productId = params.product_id;
+
+  const handleProductDelete = async () => {
+    try {
+      await fetch(reqURL + `/product/${productId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      });
+    } catch (err) {
+      const { status, data } = err.response;
+      if (status === 422) {
+        console.log(data);
+      }
+      if (status === 404) {
+        //404 이미지 출력
+      }
+
+      if (status === 500) {
+        console.log('Server error');
+      }
+    }
+  };
+
+  return handleProductDelete;
+};
+
+export default ProductDeleteAPI;

--- a/moamoa/src/Pages/Product/AskBtn.jsx
+++ b/moamoa/src/Pages/Product/AskBtn.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { useNavigate, useParams } from 'react-router-dom';
 import userNameAtom from '../../Recoil/userNameAtom';
+import ProductDeleteAPI from '../../API/Product/ProductDeleteAPI';
 
 export default function AskBtn(username) {
   const userName = useRecoilValue(userNameAtom);
@@ -14,6 +15,12 @@ export default function AskBtn(username) {
     navigate('/product/edit', { state: params });
   };
 
+  const handleProductDelete = ProductDeleteAPI(params);
+  const handleDelete = async () => {
+    await handleProductDelete();
+    navigate('/product/list');
+  };
+
   console.log(userName);
   console.log(userName.username);
   return (
@@ -23,7 +30,7 @@ export default function AskBtn(username) {
       ) : (
         <>
           <Eidt onClick={handleBtnClick}>상품수정</Eidt>
-          <Eidt>상품삭제</Eidt>
+          <Eidt onClick={handleDelete}>상품삭제</Eidt>
         </>
       )}
     </>


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유




### 작업 내역
- [x] 상품 상세 페이지에서 상품 삭제 버튼 클릭 시 삭제 api 요청을 보내서 상품을 삭제합니다.




### 작업 후 기대 동작(스크린샷) 
+ 상품(벽초지수목원 가을꽃 국화축제) 삭제 전후

![삭제 전](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/37943ac0-118f-4d29-bb39-1430719da640) |![삭제 후](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/bf6c33cb-7bdd-4618-b87f-900b6d583099) 
--- | --- | 







### PR 특이 사항
+ 상품 삭제 버튼 클릭 시 상품이 삭제되고 상품 리스트로 이동하게 처리했습니다.
+ 하지만 사용자가 실수로 삭제 버튼을 클릭하는 경우의 수도 고려하여 추가 기능으로 삭제 확인 메세지를 넣어봐도 좋을 것 같습니다!




### 특이 사항 :
Issue Number

close: # 131
