### PR TITLE
[🌈 Style] 프로필 수정 페이지 스타일 작업

### DIFF
--- a/moamoa/src/Assets/icons/icon-usertype-check.svg
+++ b/moamoa/src/Assets/icons/icon-usertype-check.svg
@@ -1,0 +1,4 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="7.5" cy="7.5" r="7.5" fill="#87B7E4"/>
+<path d="M4 7.4L6.83784 11L11 5" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/moamoa/src/Components/Common/ProfileDetail.jsx
+++ b/moamoa/src/Components/Common/ProfileDetail.jsx
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types'; // npm install prop-types 설치 필요
 import userToken from '../../Recoil/userTokenAtom'; //파일경로 변경 완료
 import userNameAtom from '../../Recoil/userNameAtom';
 import styled from 'styled-components';
+import UserTypeCheck from '../../Assets/icons/icon-usertype-check.svg';
 
 function PostCnt({ src, token, userType }) {
   const [postCount, setPostCount] = useState(0);
@@ -130,7 +131,7 @@ export default function ProfileDetail() {
               {userType === 'organization'
                 ? profileUsername.replace('[o]', '')
                 : profileUsername.replace('[i]', '')}
-              {userType === 'organization' ? <span>★</span> : ''}
+              {userType === 'organization' ? <img src={UserTypeCheck} alt='' /> : ''}
             </p>
             <p>@{profileAccountname}</p>
           </div>
@@ -181,6 +182,7 @@ const ProfileImg = styled.div`
     height: 105px;
     border-radius: 50%;
     border: 5px solid #fff;
+    background: #fff;
   }
 `;
 
@@ -204,6 +206,14 @@ const ProfileInfo = styled.div`
 
   .profile-intro {
     font-size: 14px;
+  }
+
+  div {
+    p:first-child {
+      display: flex;
+      align-items: center;
+      gap: 3px;
+    }
   }
 `;
 

--- a/moamoa/src/Components/Common/ProfileDetailPost.jsx
+++ b/moamoa/src/Components/Common/ProfileDetailPost.jsx
@@ -141,9 +141,14 @@ const Views = styled.div`
   padding-bottom: 6rem;
 
   .rlqco:first-child {
-    padding-top: 4px;
+    padding-top: 0px;
+    margin: 0px;
   }
-
+  ul {
+    li {
+      padding-top: 0px;
+    }
+  }
   li {
     width: 100%;
   }
@@ -152,11 +157,13 @@ const Views = styled.div`
 const HamView = styled.div`
   .tlJAy:first-child {
     padding: 0px;
+    margin: 0px;
   }
   article {
     margin-bottom: 20px;
   }
   article:first-child {
+    margin: 0px;
   }
 `;
 

--- a/moamoa/src/Components/Common/ProfileDetailProduct.jsx
+++ b/moamoa/src/Components/Common/ProfileDetailProduct.jsx
@@ -186,46 +186,51 @@ export default function ProfileDetailProduct() {
       <article>
         <h2>진행중인 행사</h2>
         <ProfileProductWrapper>
-          <MoveBtn>
-            <button className='left-btn' onClick={scrollLeft}>
-              <img src={leftBtn} alt='' />
-            </button>
-          </MoveBtn>
-          <ProfileProduct ref={profileProductRef}>
-            {showMyProductOptions && (
-              <MyProductClick productId={productId} closeModal={closeModal} />
-            )}
+          {eventList.length > 0 && (
+            <>
+              <MoveBtn>
+                <button className='left-btn' onClick={scrollLeft}>
+                  <img src={leftBtn} alt='' />
+                </button>
+              </MoveBtn>
 
-            <ProductListBox>
-              {eventList.map((event) => (
-                //
-                <ProductBox key={event.id}>
-                  <li key={event.id} onClick={() => handleProductClick(event.id)}>
-                    <ProductImgBox src={event.itemImage} />
-                    <p className='itemName'>{event.itemName.replace('[f]', '')}</p>
-                    <p className='itemDate'>
-                      {'행사기간: ' +
-                        `${event.price.toString().slice(2, 4)}.${event.price
-                          .toString()
-                          .slice(4, 6)}.${event.price.toString().slice(6, 8)}~${event.price
-                          .toString()
-                          .slice(10, 12)}.${event.price.toString().slice(12, 14)}.${event.price
-                          .toString()
-                          .slice(14, 16)}`}
-                    </p>
-                  </li>
-                  {showMyProductOptions && (
-                    <MyProductClick productId={productId} closeModal={closeModal} />
-                  )}
-                </ProductBox>
-              ))}
-            </ProductListBox>
-          </ProfileProduct>
-          <MoveBtn>
-            <button className='right-btn' onClick={scrollRight}>
-              <img src={rightBtn} alt='' />
-            </button>
-          </MoveBtn>
+              <ProfileProduct ref={profileProductRef}>
+                {showMyProductOptions && (
+                  <MyProductClick productId={productId} closeModal={closeModal} />
+                )}
+
+                <ProductListBox>
+                  {eventList.map((event) => (
+                    //
+                    <ProductBox key={event.id}>
+                      <li key={event.id} onClick={() => handleProductClick(event.id)}>
+                        <ProductImgBox src={event.itemImage} />
+                        <p className='itemName'>{event.itemName.replace('[f]', '')}</p>
+                        <p className='itemDate'>
+                          {'행사기간: ' +
+                            `${event.price.toString().slice(2, 4)}.${event.price
+                              .toString()
+                              .slice(4, 6)}.${event.price.toString().slice(6, 8)}~${event.price
+                              .toString()
+                              .slice(10, 12)}.${event.price.toString().slice(12, 14)}.${event.price
+                              .toString()
+                              .slice(14, 16)}`}
+                        </p>
+                      </li>
+                      {showMyProductOptions && (
+                        <MyProductClick productId={productId} closeModal={closeModal} />
+                      )}
+                    </ProductBox>
+                  ))}
+                </ProductListBox>
+              </ProfileProduct>
+              <MoveBtn>
+                <button className='right-btn' onClick={scrollRight}>
+                  <img src={rightBtn} alt='' />
+                </button>
+              </MoveBtn>
+            </>
+          )}
         </ProfileProductWrapper>
       </article>
     </ProductItro>

--- a/moamoa/src/Components/Post/PostCardList.jsx
+++ b/moamoa/src/Components/Post/PostCardList.jsx
@@ -75,7 +75,7 @@ export default function PostCardList(post) {
 
 const PostList = styled.li`
   &:first-child {
-    padding-top: 1.5rem;
+    padding-top: 0rem;
   }
   margin-bottom: 25px;
 `;

--- a/moamoa/src/Pages/Home/Home.jsx
+++ b/moamoa/src/Pages/Home/Home.jsx
@@ -76,5 +76,5 @@ const PostList = styled.div`
   height: 100%;
   margin: auto;
   background-color: #ffffff;
-  padding: 0 1.6rem 8rem;
+  padding: 15px 1.6rem 8rem;
 `;

--- a/moamoa/src/Pages/Post/UloadEditPostStyle.jsx
+++ b/moamoa/src/Pages/Post/UloadEditPostStyle.jsx
@@ -2,10 +2,12 @@ import styled from 'styled-components';
 
 export const HeaderContainer = styled.header`
   display: flex;
-  height: 55px;
+  height: 48px;
+  min-height: 48px;
+  max-height: 48px;
   width: 390px;
   justify-content: space-between;
-  border-bottom: 2px solid #dbdbdb;
+  border-bottom: 1px solid #dbdbdb;
   background-color: #fff;
   align-items: center;
   font-size: 24px;

--- a/moamoa/src/Pages/Profile/EditProfile.jsx
+++ b/moamoa/src/Pages/Profile/EditProfile.jsx
@@ -9,6 +9,13 @@ import React, { useState, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useNavigate } from 'react-router-dom';
 import userToken from '../../Recoil/userTokenAtom'; //파일경로 변경완료
+import { Container } from '../../Components/Common/Container';
+import Gobackbtn from '../../Components/Common/GoBackbtn';
+import ButtonSubmit from '../../Components/Common/Button';
+import uploadFile from '../../Assets/images/upload-file.png';
+import styled from 'styled-components';
+
+import { HeaderContainer, HiddenH1 } from '../Post/UloadEditPostStyle';
 
 function EditProfile() {
   //기존 사용자의 정보를 가져오기
@@ -187,67 +194,154 @@ function EditProfile() {
   };
 
   return (
-    <>
+    <Container>
+      <HeaderContainer>
+        <Gobackbtn />
+        <ButtonSubmit buttonText='저장' onClickHandler={submitEdit} disabled={isButtonDisabled} />
+      </HeaderContainer>
+
       <section>
-        <h1>내 프로필 수정</h1>
+        <HiddenH1>내 프로필 수정</HiddenH1>
         <form onSubmit={handleFormSubmit}>
-          <label htmlFor='profileImg'>
-            <img src={imgSrc || initImgSrc} alt='Profile' id='imagePre' />
-          </label>
-          <input
-            type='file'
-            onChange={handleChangeImage}
-            id='profileImg'
-            name='image'
-            accept='image/*'
-            required
-          />
-          <p style={{ color: 'red' }}>{errorMessage}</p>
-          <div>
-            <label htmlFor='userNameInput'>사용자 이름</label>
+          {/* 프로필 이미지 */}
+          <ProfileImg>
+            <label htmlFor='profileImg'>
+              <img src={imgSrc || initImgSrc} alt='Profile' id='imagePre' />
+              <img src={uploadFile} alt='' />
+            </label>
             <input
-              value={username}
-              onChange={inputUsername}
-              type='text'
-              id='userNameInput'
-              name='username'
-              placeholder='2~10자 이내여야 합니다.'
+              type='file'
+              onChange={handleChangeImage}
+              id='profileImg'
+              name='image'
+              accept='image/*'
+              style={{ display: 'none' }}
               required
             />
-            {userNameError && <p style={{ color: 'red' }}>{userNameError}</p>}
-          </div>
-          <div>
-            <label htmlFor='userIdInput'>계정 ID</label>
-            <input
-              value={accountname}
-              onChange={inputAccountname}
-              type='text'
-              id='userIdInput'
-              name='accountname'
-              placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
-              required
-            />
-            {duplicateIdError && <p style={{ color: 'red' }}>{duplicateIdError}</p>}
-            {accountError && <p style={{ color: 'red' }}>{accountError}</p>}
-          </div>
-          <div>
-            <label htmlFor='userIntroInput'>소개</label>
-            <input
-              value={intro}
-              onChange={inputInfo}
-              type='text'
-              id='userIntroInput'
-              name='intro'
-              placeholder='자신과 판매할 상품에 대해 소개해 주세요!'
-              required
-            />
-          </div>
-          <button type='button' onClick={submitEdit} disabled={isButtonDisabled}>
-            수정하기
-          </button>
+            <EorrorMsg style={{ color: 'red' }}>{errorMessage}</EorrorMsg>
+          </ProfileImg>
+          <EditProfileBox>
+            <div>
+              <TextLabel>
+                <label htmlFor='userNameInput'>사용자 이름</label>
+              </TextLabel>
+              <TextInput>
+                <input
+                  value={username}
+                  onChange={inputUsername}
+                  type='text'
+                  id='userNameInput'
+                  name='username'
+                  placeholder='2~10자 이내여야 합니다.'
+                  required
+                />
+              </TextInput>
+              {userNameError && <EorrorMsg>{userNameError}</EorrorMsg>}
+            </div>
+            <div>
+              <TextLabel>
+                <label htmlFor='userIdInput'>계정 ID</label>
+              </TextLabel>
+              <TextInput>
+                <input
+                  value={accountname}
+                  onChange={inputAccountname}
+                  type='text'
+                  id='userIdInput'
+                  name='accountname'
+                  placeholder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+                  required
+                />
+              </TextInput>
+              {duplicateIdError && <EorrorMsg>{duplicateIdError}</EorrorMsg>}
+              {accountError && <EorrorMsg>{accountError}</EorrorMsg>}
+            </div>
+            <div>
+              <TextLabel>
+                <label htmlFor='userIntroInput'>소개</label>
+              </TextLabel>
+              <TextInput>
+                <input
+                  value={intro}
+                  onChange={inputInfo}
+                  type='text'
+                  id='userIntroInput'
+                  name='intro'
+                  placeholder='자신과 판매할 상품에 대해 소개해 주세요!'
+                  required
+                />
+              </TextInput>
+            </div>
+          </EditProfileBox>
         </form>
       </section>
-    </>
+    </Container>
   );
 }
 export default EditProfile;
+
+const ProfileImg = styled.div`
+  background: linear-gradient(to bottom, #ffc700 50%, #ffc700 calc(30% + 65px), transparent 50%);
+  padding-top: 65px;
+  padding-left: 20px;
+
+  label {
+    cursor: pointer;
+    position: relative;
+
+    img:first-child {
+      width: 105px;
+      height: 105px;
+      border-radius: 50%;
+      border: 5px solid #fff;
+      background: #fff;
+    }
+
+    img:last-child {
+      width: 40px;
+      height: 40px;
+      position: absolute;
+      bottom: 0px;
+      left: 85px;
+    }
+  }
+`;
+
+const EditProfileBox = styled.div`
+  // background: yellow;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+
+  gap: 16px;
+`;
+
+const TextInput = styled.div`
+  width: 100%;
+  input {
+    width: 100%;
+    border: none;
+    outline: none;
+    border-bottom: 1.5px solid #dbdbdb;
+    letter-spacing: -1px;
+    padding: 8px 0;
+
+    font-size: 14px;
+
+    &:focus {
+      border-bottom: 1.5px solid #ffc700;
+      transition: border-color 0.3s ease-in-out;
+    }
+  }
+`;
+
+const TextLabel = styled.div`
+  font-size: 12px;
+  color: #767676;
+`;
+
+const EorrorMsg = styled.p`
+  color: red;
+  text-align: left;
+  margin-top: 6px;
+`;


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
- PostCardList.jsx : 프로필 상세 페이지에서 어색하게 출력되어 padding-top을 수정하였습니다.
- Home.jsx : PostCardList의 padding값 조정으로 발생한 어색한 부분을 수정하였습니다.
- 프로필 수정, 게시글 등록, 게시글 수정 페이지에서 쓰이는 헤더의 높이와 border-bottom을 다른 헤더와 동일하게 수정했습니다.

### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
프로필 상세 페이지
- 판매자 계정 인증 아이콘을 수정하였습니다.
- 사용자 프로필 이미지의 배경이 투명일 경우 화면 뒷배경이 비쳐 보이는 부분을 하얗게 바꾸었습니다.
- 판매자 계정에서 상품이 하나도 등록되지 않았을 경우 발생한 레이아웃 오류를 수정했습니다.
- 게시글 목록 부분에서 어색한 레이아웃을 수정하였습니다.

프로필 수정 페이지
- 사용자 프로필 이미지 또는 카메라 아이콘을 클릭할 시 파일 선택 창이 뜰 수 있도록 했습니다.
- input text에 focus가 가면 border-bottom의 색이 바뀌도록 했습니다.
- 사용자 프로필 이미지의 배경이 투명일 경우 화면 배경이 하얗게 되도록 설정했습니다.

### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
| 프로필 상세 페이지 수정 | 프로필 수정 페이지 스타일 작업 |
| --- | --- |
| ![프로필 상세 스타일 수정](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/116999139/50ee75b7-444e-4082-8403-06f59883808d) | ![프로필 수정 페이지](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/116999139/74a7f80f-ea86-42ce-8b6f-c0479383ec7b) |




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
계획
- 프로필 상세페이지 헤더 부분의 케밥을 버튼 눌렀을 때 뜨는 모달 창을 구현합니다.
- 로그아웃 기능을 구현합니다.



### 특이 사항 :
Issue Number #133 
