### PR TITLE
[🔧 Fix] 기본 프로필 이미지로 회원가입 시 프로필 이미지가 뜨지 않는 문제 수정

### DIFF
--- a/moamoa/src/API/Img/UploadImageAPI.jsx
+++ b/moamoa/src/API/Img/UploadImageAPI.jsx
@@ -13,8 +13,7 @@ export const uploadImage = async (imageFile) => {
       },
     });
 
-    const filename = `https://api.mandarin.weniv.co.kr/${res.data.filename}`;
-    return filename;
+    return res;
   } catch (error) {
     console.error('이미지 업로드 실패');
   }

--- a/moamoa/src/Hooks/Sign/useJoin.jsx
+++ b/moamoa/src/Hooks/Sign/useJoin.jsx
@@ -18,7 +18,7 @@ const useJoin = () => {
       password: '',
       accountname: '',
       intro: '',
-      image: '',
+      image: 'https://api.mandarin.weniv.co.kr/1698856499022.png',
     },
   });
 

--- a/moamoa/src/Pages/Join/Join.jsx
+++ b/moamoa/src/Pages/Join/Join.jsx
@@ -4,8 +4,8 @@ import useJoin from '../../Hooks/Sign/useJoin.jsx';
 import styled from 'styled-components';
 import { Container } from '../../Components/Common/Container';
 import { Form, Input, Button, StyledErrorMsg } from '../../Components/Common/FormLoginAndJoin';
-import DefaultProfileImg from '../../Assets/images/profile-img.svg';
 import UploadFile from '../../Assets/images/upload-file.png';
+import DefaultProfile from '../../Assets/images/profile-img.svg';
 
 const Join = () => {
   const {
@@ -29,8 +29,15 @@ const Join = () => {
   const handleChangeImage = async (e) => {
     const imageFile = e.target.files[0];
     const response = await uploadImage(imageFile);
-    setUserInfo({ ...userInfo, user: { ...userInfo.user, image: response } });
-    setImgSrc(response);
+    setUserInfo({
+      ...userInfo,
+      user: {
+        ...userInfo.user,
+        image: `https://api.mandarin.weniv.co.kr/${response.data.filename}`,
+      },
+    });
+
+    setImgSrc(`https://api.mandarin.weniv.co.kr/${response.data.filename}`);
   };
 
   return (
@@ -42,12 +49,7 @@ const Join = () => {
           <ProfileForm onSubmit={handleSubmit}>
             <ImgContainer>
               <ImgLabel htmlFor='profileImg'>
-                <ProfileImg
-                  src={imgSrc ? imgSrc : DefaultProfileImg}
-                  alt=''
-                  srcSet=''
-                  id='imagePre'
-                />
+                <ProfileImg src={imgSrc ? imgSrc : DefaultProfile} alt='' srcSet='' id='imagePre' />
               </ImgLabel>
               <input
                 type='file'


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 회원가입 시 사용자가 프로필 이미지를 등록하지 않으면 기본 프로필 이미지로 가입이 됩니다.   
하지만 로그인 후 프로필 페이지를 확인해보니 이미지가 뜨지 않는 현상이 발생하여 해결했습니다.




### 작업 내역
+ UploadImageAPI return 값을 수정하고 useJoin에서 이미지 초기값으로 기본 프로필 이미지를 등록했습니다.




### 작업 후 기대 동작(스크린샷) 

![기본 프로필](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/7a57c572-3ec0-4589-b6ee-af3de21b1189) |![사용자 선택](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/2b58cc81-624d-4bf3-a12b-9101ae363072)
--- | --- | 






### PR 특이 사항





### 특이 사항 :
Issue Number

close: # 165
