### PR TITLE
[✨ Feature] 회원가입(프로필 설정) 글자 수 입력 조건 설정

### DIFF
--- a/moamoa/src/Hooks/Sign/useJoin.jsx
+++ b/moamoa/src/Hooks/Sign/useJoin.jsx
@@ -9,6 +9,8 @@ const useJoin = () => {
   const [passwordError, setPasswordError] = useState('');
   const [imgSrc, setImgSrc] = useState();
   const [errorMessage, setErrorMessage] = useState('');
+  const [accountInfoMsg, setAccountInfoMsg] = useState('');
+  const [introInfoMsg, setIntroInfoMsg] = useState('');
   const [pageTransition, setPageTransition] = useState(false);
   const [userType, setUserType] = useState('');
   const [userInfo, setUserInfo] = useState({
@@ -59,6 +61,20 @@ const useJoin = () => {
     }
   };
 
+  const handleAccountNameValid = () => {
+    setAccountInfoMsg('2~15자 이내여야 합니다.');
+    if (userInfo.user.accountname.length > 1 || errorMessage) {
+      setAccountInfoMsg('');
+    }
+  };
+
+  const handleIntroValid = () => {
+    setIntroInfoMsg('2~50자 이내여야 합니다.');
+    if (userInfo.user.intro.length > 1 || errorMessage) {
+      setIntroInfoMsg('');
+    }
+  };
+
   const goNext = (e) => {
     e.preventDefault();
     if (userInfo.user.email && userInfo.user.password && !passwordError) {
@@ -95,12 +111,16 @@ const useJoin = () => {
     pageTransition,
     emailError,
     passwordError,
+    accountInfoMsg,
+    introInfoMsg,
     errorMessage,
     handleSubmit,
     handleInputChange,
     handleUserType,
     handlePasswordValid,
     handleEmailOnBlur,
+    handleAccountNameValid,
+    handleIntroValid,
   };
 };
 

--- a/moamoa/src/Pages/Join/Join.jsx
+++ b/moamoa/src/Pages/Join/Join.jsx
@@ -22,8 +22,12 @@ const Join = () => {
     goNext,
     emailError,
     passwordError,
+    accountInfoMsg,
+    introInfoMsg,
     errorMessage,
     handlePasswordValid,
+    handleAccountNameValid,
+    handleIntroValid,
   } = useJoin();
 
   const handleChangeImage = async (e) => {
@@ -69,6 +73,8 @@ const Join = () => {
                 id='userNameInput'
                 name='username'
                 placeholder='2~10자 이내여야 합니다.'
+                minLength={2}
+                maxLength={10}
               />
               <TextLabel htmlFor='userIdInput'>계정 ID</TextLabel>
               <TextInput
@@ -78,7 +84,11 @@ const Join = () => {
                 id='userIdInput'
                 name='accountname'
                 placeholder='영문, 숫자, 특수문자(,), (_)만 사용 가능합니다.'
+                minLength={2}
+                maxLength={15}
+                onBlur={handleAccountNameValid}
               />
+              <StyledErrorMsg>{accountInfoMsg}</StyledErrorMsg>
               {errorMessage === '*영문, 숫자, 밑줄, 마침표만 사용할 수 있습니다.' && (
                 <StyledErrorMsg>{errorMessage}</StyledErrorMsg>
               )}
@@ -97,7 +107,11 @@ const Join = () => {
                     ? '자신과 홍보할 행사에 대해 소개해 주세요!'
                     : '자신에 대해 소개해 주세요!'
                 }
+                minLength={2}
+                maxLength={50}
+                onBlur={handleIntroValid}
               />
+              <StyledErrorMsg>{introInfoMsg}</StyledErrorMsg>
             </TextContainer>
             <ProfileButton
               type='submit'


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ UI 요소를 일관되게 유지하기 위해 회원가입 시 계정명과 소개란에 글자 수 입력 조건을 설정했습니다.



### 작업 내역
-  [x] 회원가입(프로필 설정) 글자 수 입력 조건 추가
    - [x]  사용자명 2~10자 이내
    - [x]  계정 ID 2~15자 이내
    - [x]  소개 2~50자 이내
  
- [x] 사용자들이 회원가입 폼 제출 후 다시 수정하는 일이 없도록 input(계정ID, 소개)에 onBlur를 사용하여 글자 수 안내 문구를 추가했습니다.




### 작업 후 기대 동작(스크린샷) 

![onBlur](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/8f71e90d-352a-441e-a6a6-396877d79f58) |![테스트](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/25ad9b7d-d18a-4e33-8e1f-d4df9376c9f6)
--- | --- | 





### PR 특이 사항





### 특이 사항 :
Issue Number

close: # 178
