### PR TITLE
[🔧 Fix] 상품 등록과 상품 수정 페이지 스타일 수정 및 상품 명 글자 수 제한 설정

### DIFF
--- a/moamoa/src/Components/Common/ProductSharedStyle.jsx
+++ b/moamoa/src/Components/Common/ProductSharedStyle.jsx
@@ -4,26 +4,19 @@ import UploadFile from '../../Assets/images/upload-file.png';
 
 export const Form = styled.form`
   padding: 0 34px;
-  margin-top: 78px;
+  margin-top: 30px;
   display: flex;
   flex-direction: column;
-  background-color: #fff;
   gap: 18px;
+  background-color: #fff;
 `;
 
 export const Header = styled.header`
-  position: fixed;
-  z-index: 10;
-  width: 390px;
   display: flex;
   padding: 8px 16px;
-
   justify-content: space-between;
   align-items: center;
-  background-color: #fff;
   border-bottom: 1px solid #dbdbdb;
-
-  box-sizing: border-box;
 `;
 
 export const HeaderButton = styled.button`
@@ -36,7 +29,7 @@ export const HeaderButton = styled.button`
   border-radius: 32px;
 `;
 
-export const FirstContainer = styled.div`
+export const ImgLayoutContainer = styled.div`
   position: relative;
 
   h2 {
@@ -45,20 +38,10 @@ export const FirstContainer = styled.div`
   }
 
   p {
-    position: absolute;
-    right: 0;
-    bottom: 11px;
     color: #979797;
+    text-align: right;
+    margin-top: 7px;
   }
-`;
-
-export const ImgLayoutContainer = styled.div`
-  width: 322px;
-  height: 206px;
-  overflow: hidden;
-  margin: 0 auto 30px;
-  position: relative;
-  border-radius: 10px;
 `;
 
 export const ImageLabel = styled.label`
@@ -74,15 +57,16 @@ export const ImageLabel = styled.label`
     height: 36px;
     border-radius: 50%;
     right: 10px;
-    bottom: 10px;
+    bottom: 30px;
     background: url(${UploadFile}) 0 0 / cover;
   }
 `;
 
 export const Image = styled.img`
-  max-width: 100%;
-  height: auto;
+  width: 100%;
+  aspect-ratio: 322/204;
   object-fit: cover;
+  border-radius: 10px;
 `;
 
 export const LayoutContainer = styled.div`
@@ -156,6 +140,8 @@ export const Textarea = styled.textarea`
   height: 145px;
   border-radius: 5px;
   border: 2px solid #dbdbdb;
+  margin-bottom: 60px;
+  font-size: 13px;
 
   &:focus {
     border-color: #87b7e4;

--- a/moamoa/src/Pages/Product/AddProduct.jsx
+++ b/moamoa/src/Pages/Product/AddProduct.jsx
@@ -9,7 +9,6 @@ import {
   Form,
   Header,
   HeaderButton,
-  FirstContainer,
   ImgLayoutContainer,
   ImageLabel,
   Image,
@@ -84,11 +83,12 @@ const AddProduct = () => {
             onClick={submitProduct}
             disabled={
               !imgSrc ||
-              !eventName ||
+              eventName.length < 2 ||
               !eventStartDate ||
               !eventEndDate ||
               !eventDetail ||
-              !eventType
+              !eventType ||
+              eventStartDate > eventEndDate
             }
           >
             저장
@@ -96,22 +96,20 @@ const AddProduct = () => {
         </Header>
         <h1 className='a11y-hidden'>상품 등록 페이지</h1>
         <Form>
-          <FirstContainer>
+          <ImgLayoutContainer>
             <h2>이미지 등록</h2>
-            <ImgLayoutContainer>
-              <ImageLabel htmlFor='upload-file'>
-                <Image src={imgSrc ? imgSrc : DefaultImg} alt={eventName} />
-              </ImageLabel>
-              <input
-                className='a11y-hidden'
-                id='upload-file'
-                type='file'
-                accept='image/*'
-                onChange={handleChangeImage}
-              ></input>
-            </ImgLayoutContainer>
+            <ImageLabel htmlFor='upload-file'>
+              <Image src={imgSrc ? imgSrc : DefaultImg} alt={eventName} />
+            </ImageLabel>
+            <input
+              className='a11y-hidden'
+              id='upload-file'
+              type='file'
+              accept='image/*'
+              onChange={handleChangeImage}
+            ></input>
             <p>* 행사 관련 이미지를 등록해주세요.</p>
-          </FirstContainer>
+          </ImgLayoutContainer>
           <LayoutContainer>
             <label htmlFor='category'>카테고리</label>
             <div>
@@ -143,6 +141,8 @@ const AddProduct = () => {
               title='2~22자 이내여야 합니다.'
               onChange={(e) => setEventName(e.target.value)}
               value={eventName}
+              minLength={2}
+              maxLength={22}
             ></EventNameInput>
           </LayoutContainer>
           <LayoutContainer>

--- a/moamoa/src/Pages/Product/EditProduct.jsx
+++ b/moamoa/src/Pages/Product/EditProduct.jsx
@@ -10,7 +10,6 @@ import {
   Form,
   Header,
   HeaderButton,
-  FirstContainer,
   ImgLayoutContainer,
   ImageLabel,
   Image,
@@ -148,11 +147,12 @@ const EditProduct = () => {
           onClick={editProduct}
           disabled={
             !productInputs.product.itemImage ||
-            !productInputs.product.itemName ||
+            productInputs.product.itemName.length < 2 ||
             !eventStartDate ||
             !eventEndDate ||
             !productInputs.product.link ||
-            !eventType
+            !eventType ||
+            eventStartDate > eventEndDate
           }
         >
           수정
@@ -160,25 +160,23 @@ const EditProduct = () => {
       </Header>
       <h1 className='a11y-hidden'>상품 수정 페이지</h1>
       <Form>
-        <FirstContainer>
+        <ImgLayoutContainer>
           <h2>이미지 등록</h2>
-          <ImgLayoutContainer>
-            <ImageLabel htmlFor='upload-file'>
-              <Image
-                src={productInputs.product.itemImage || DefaultImg}
-                alt={productInputs.product.itemName}
-              />
-            </ImageLabel>
-            <input
-              className='a11y-hidden'
-              id='upload-file'
-              type='file'
-              accept='image/*'
-              onChange={handleChangeImage}
-            ></input>
-          </ImgLayoutContainer>
+          <ImageLabel htmlFor='upload-file'>
+            <Image
+              src={productInputs.product.itemImage || DefaultImg}
+              alt={productInputs.product.itemName}
+            />
+          </ImageLabel>
+          <input
+            className='a11y-hidden'
+            id='upload-file'
+            type='file'
+            accept='image/*'
+            onChange={handleChangeImage}
+          ></input>
           <p>* 행사 관련 이미지를 등록해주세요.</p>
-        </FirstContainer>
+        </ImgLayoutContainer>
         <LayoutContainer>
           <label htmlFor='category'>카테고리</label>
           <div>
@@ -211,6 +209,8 @@ const EditProduct = () => {
             onChange={handleInputChange}
             name='itemName'
             value={productInputs.product.itemName}
+            minLength={2}
+            maxLength={22}
           ></EventNameInput>
         </LayoutContainer>
         <LayoutContainer>


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 상품 등록 페이지와 상품 수정 페이지의 스타일 수정했습니다.
+ 상품 등록 페이지와 상품 수정 페이지의 상품 명(행사 명)의 글자 수를 제한 설정했습니다.


### 작업 내역
  - [x]  상품 이미지 등록 박스 크기 조정
   - [x]  상세 설명(textarea) 밑 margin
   - [x]  상세 설명(textarea) 글자 크기 up
   - [x]  화면 확대 시 비는 배경 채우기
   - [x]  행사명 2~22자 제한 




### 작업 후 기대 동작(스크린샷) 
![결과](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/fc0884c4-8d0d-426d-ac8e-4514603952c4)




### PR 특이 사항




### 특이 사항 :
Issue Number

close: # 186
