### PR TITLE
[✨ Feature] 사용자의 로그인 상태에 따른 경로 접근 제한

### DIFF
--- a/moamoa/src/Components/Common/HeaderKebab.jsx
+++ b/moamoa/src/Components/Common/HeaderKebab.jsx
@@ -3,6 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import userToken from '../../Recoil/userTokenAtom';
+import isLoginAtom from '../../Recoil/isLoginAtom';
+import accountNameAtom from '../../Recoil/accountNameAtom';
+import userNameAtom from '../../Recoil/userNameAtom';
 
 import Gobackbtn from '../../Components/Common/GoBackbtn';
 import more from '../../Assets/icons/icon-more.svg';
@@ -13,6 +16,9 @@ import ConfirmLogoutModal from '../../Components/Modal/ConfirmLogoutModal';
 export default function HeaderKebab() {
   const navigate = useNavigate();
   const setToken = useSetRecoilState(userToken);
+  const setIsLoginState = useSetRecoilState(isLoginAtom);
+  const setAccountName = useSetRecoilState(accountNameAtom);
+  const setUserName = useSetRecoilState(userNameAtom);
 
   const [showMyProfileOptions, setShowMyProfileOptions] = useState(false);
   const [showConfirmLogoutModal, setShowConfirmLogoutModal] = useState(false);
@@ -33,6 +39,9 @@ export default function HeaderKebab() {
 
     setToken('');
     localStorage.removeItem('token');
+    setIsLoginState(false);
+    setAccountName('');
+    setUserName('');
     navigate('/user/login');
   };
 

--- a/moamoa/src/Router/AppRoutes.js
+++ b/moamoa/src/Router/AppRoutes.js
@@ -30,9 +30,10 @@ import ChatRoomAccount from '../Pages/Chat/ChatRoomAccount';
 
 // import ChatRoom from '../Pages/Chat/ChatRoom';
 // import ChatList from '../Pages/Chat/ChatList';
+// import Search from '../Pages/Search/Search';
 
 import NotFound from '../Pages/NotFound';
-// import Search from '../Pages/Search/Search';
+import PrivateRoute from './PrivateRoute';
 
 export default function AppRoutes() {
   return (
@@ -40,64 +41,66 @@ export default function AppRoutes() {
       {/* 시작 */}
       <Route path='/' element={<Landing />} />
 
-      {/* 홈 */}
-      <Route path='/home' element={<Home />} />
-
       {/* 로그인 */}
       <Route path='/user/login' element={<Login />} />
 
       {/* 회원가입 */}
       <Route path='/user/join' element={<Join />} />
 
-      {/* 내 프로필 */}
-      <Route path='/profile/myInfo' element={<MyProfile />} />
-
-      {/* 남의 프로필 */}
-      <Route path='/profile/:accountname' element={<YourProfile />} />
-
-      {/* 내 프로필 수정*/}
-      <Route path='/profile/edit' element={<EditProfile />} />
-      {/* 공통파일 프로필 수정 경로추가 */}
-
-      {/* 팔로워 리스트*/}
-      <Route path='profile/:accountname/follower' element={<FollowerList />} />
-      {/*  팔로잉 리스트 */}
-      <Route path='profile/:accountname/following' element={<FollowingList />} />
-
-      {/* 상품 등록 */}
-      <Route path='/product' element={<AddProduct />} />
-
-      {/* 상품 수정 */}
-      <Route path='/product/edit' element={<EditProduct />} />
-
-      {/* 상품 리스트 */}
-      <Route path='/product/list' element={<ProductList />} />
-
-      {/* 상품 상세 */}
-      <Route path='/product/detail/:product_id' element={<ProductDetail />} />
-
-      {/* 게시글 작성 */}
-      <Route path='/post' element={<UploadPost />} />
-
-      {/* 게시글 수정 */}
-      <Route path='/post/edit/:post_id' element={<EditPost />} />
-
-      {/* 게시글 상세 */}
-      <Route path='/post/:post_id' element={<PostDetail />} />
-
-      {/* 채팅 리스트 */}
-      <Route path='/chat' element={<ChatList />} />
-      {/* 검색 페이지 */}
-      <Route path='/search' element={<Search />} />
-      {/* 채팅 리스트 */}
-      <Route path='/chat/kim' element={<ChatRoomKim />} />
-      <Route path='/chat/sumiDad' element={<ChatRoomSumiDad />} />
-      <Route path='/chat/darkHorse' element={<ChatRoomDarkHorse />} />
-
-      <Route path='/chat/:chatUserName' element={<ChatRoomAccount />} />
-
       {/* 404 페이지} */}
       <Route path='/*' element={<NotFound />} />
+
+      <Route element={<PrivateRoute />}>
+        {/* 홈 */}
+        <Route path='/home' element={<Home />} />
+
+        {/* 내 프로필 */}
+        <Route path='/profile/myInfo' element={<MyProfile />} />
+
+        {/* 남의 프로필 */}
+        <Route path='/profile/:accountname' element={<YourProfile />} />
+
+        {/* 내 프로필 수정*/}
+        <Route path='/profile/edit' element={<EditProfile />} />
+        {/* 공통파일 프로필 수정 경로추가 */}
+
+        {/* 팔로워 리스트*/}
+        <Route path='profile/:accountname/follower' element={<FollowerList />} />
+        {/*  팔로잉 리스트 */}
+        <Route path='profile/:accountname/following' element={<FollowingList />} />
+
+        {/* 상품 등록 */}
+        <Route path='/product' element={<AddProduct />} />
+
+        {/* 상품 수정 */}
+        <Route path='/product/edit' element={<EditProduct />} />
+
+        {/* 상품 리스트 */}
+        <Route path='/product/list' element={<ProductList />} />
+
+        {/* 상품 상세 */}
+        <Route path='/product/detail/:product_id' element={<ProductDetail />} />
+
+        {/* 게시글 작성 */}
+        <Route path='/post' element={<UploadPost />} />
+
+        {/* 게시글 수정 */}
+        <Route path='/post/edit/:post_id' element={<EditPost />} />
+
+        {/* 게시글 상세 */}
+        <Route path='/post/:post_id' element={<PostDetail />} />
+
+        {/* 채팅 리스트 */}
+        <Route path='/chat' element={<ChatList />} />
+        {/* 검색 페이지 */}
+        <Route path='/search' element={<Search />} />
+        {/* 채팅 리스트 */}
+        <Route path='/chat/kim' element={<ChatRoomKim />} />
+        <Route path='/chat/sumiDad' element={<ChatRoomSumiDad />} />
+        <Route path='/chat/darkHorse' element={<ChatRoomDarkHorse />} />
+
+        <Route path='/chat/:chatUserName' element={<ChatRoomAccount />} />
+      </Route>
     </Routes>
   );
 }

--- a/moamoa/src/Router/PrivateRoute.js
+++ b/moamoa/src/Router/PrivateRoute.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import isLoginAtom from '../Recoil/isLoginAtom';
+
+export default function PrivateRoute() {
+  const isLogin = useRecoilValue(isLoginAtom);
+
+  return isLogin ? <Outlet /> : <Navigate to={'/'} replace />;
+}


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 사용자가 로그아웃 상태일 시 일부 페이지 접근을 제한합니다.
+ splash, 로그인, 회원가입, 404 페이지는 예외입니다.
+ **구현을 위하여 HeaderKebab.jsx와 AppRoutes.js 파일을 수정했습니다.**


### 작업 내역
- [x] 로그아웃 클릭 시 isLoginAtom, accountNameAtom, userNameAtom이 초기화되도록 합니다.
- [x] 페이지 접근을 제한하기 위해 PrivateRoute 컴포넌트를 생성하였습니다.
- [x] 위 컴포넌트 내부에서 사용자의 isLoginAtom이 false일 경우 splash 페이지로 이동, true일 경우 원하는 페이지로 이동하도록 구현했습니다.




### 작업 후 기대 동작(스크린샷) 




### PR 특이 사항




### 특이 사항 :
Issue Number

close: # 197
