### PR TITLE
[🔧 Fix] 프로필 설정 시 사용자명 글자 수 입력조건 미충족임에도 버튼 활성화되는 문제 및 스타일 수정

### DIFF
--- a/moamoa/src/Components/Common/FormLoginAndJoin.jsx
+++ b/moamoa/src/Components/Common/FormLoginAndJoin.jsx
@@ -3,13 +3,14 @@ import Email from '../../Assets/icons/icon-email.svg';
 import Lock from '../../Assets/icons/icon-lock.svg';
 
 export const Form = styled.form`
-  margin: 0 34px;
+  padding: 0 34px;
   display: flex;
   flex-direction: column;
   text-align: center;
   color: #767676;
   font-size: 12px;
-  margin-top: 45px;
+  margin: 45px 0 0 0;
+  background-color: #fff;
 `;
 
 export const Input = styled.input`
@@ -33,7 +34,7 @@ export const Button = styled.button`
   font-weight: 700;
   padding: 11px;
   color: white;
-  margin: 26px 0 21px 0;
+  margin: 26px 0 80px 0;
   letter-spacing: -1px;
 `;
 

--- a/moamoa/src/Pages/Join/Join.jsx
+++ b/moamoa/src/Pages/Join/Join.jsx
@@ -116,7 +116,9 @@ const Join = () => {
             <ProfileButton
               type='submit'
               disabled={
-                !userInfo.user.username || !userInfo.user.accountname || !userInfo.user.intro
+                userInfo.user.username.length < 2 ||
+                !userInfo.user.accountname ||
+                !userInfo.user.intro
               }
             >
               모아모아 시작하기
@@ -229,7 +231,9 @@ const ProfileInfo = styled.p`
 `;
 
 const ProfileForm = styled.form`
-  margin: 0 34px;
+  padding: 0 34px;
+  background-color: #fff;
+  margin-bottom: 60px;
 `;
 
 const ImgContainer = styled.div`

--- a/moamoa/src/Pages/Login/Login.jsx
+++ b/moamoa/src/Pages/Login/Login.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import useLogin from '../../Hooks/Sign/useLogin';
 import styled from 'styled-components';
 import { Container } from '../../Components/Common/Container';
-import { Form, Input, Button, StyledErrorMsg } from '../../Components/Common/FormLoginAndJoin';
+import { Form, Input, StyledErrorMsg } from '../../Components/Common/FormLoginAndJoin';
 
 const LoginPage = () => {
   const {
@@ -51,7 +51,9 @@ const LoginPage = () => {
         >
           로그인
         </Button>
-        <Link to='/user/join'>이메일로 회원가입</Link>
+        <LinkContainer>
+          <Link to='/user/join'>이메일로 회원가입</Link>
+        </LinkContainer>
       </Form>
     </Container>
   );
@@ -62,6 +64,20 @@ const H1 = styled.h1`
   font-weight: 400;
   font-size: 24px;
   margin-top: 30px;
+`;
+
+const Button = styled.button`
+  background-color: ${(props) => (props.disabled ? '#D8E7F5' : '#87B7E4')};
+  border-radius: 44px;
+  font-weight: 700;
+  padding: 11px;
+  color: white;
+  margin: 26px 0 21px 0;
+  letter-spacing: -1px;
+`;
+
+const LinkContainer = styled.div`
+  margin-bottom: 80px;
 `;
 
 export default LoginPage;


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 회원 가입 시 프로필 설정에서 사용자 명 글자 수 제한은 2~10자 이내입니다.
+ 폼 제출 할 때는 2자 이상 출력하라는 안내 문구와 함께 제출이 되지 않습니다.
+ 하지만 이전 단계인 버튼 활성화 단계에서 사용자 명이 1글자임에도 활성화되어 이를 수정했습니다.



### 작업 내역
+ 프로필 설정 페이지에서 버튼 활성화 조건 수정(사용자 명 글자 수 2자 이상)
+ 로그인, 회원 가입, 프로필 설정 페이지에서 화면 확대 시 비는 배경 채우기, 여백 주기 완료


### 작업 후 기대 동작(스크린샷) 



### PR 특이 사항




### 특이 사항 :
Issue Number

close: # 199
