### PR TITLE
[✨ Feature / 🌈 Style / 🔧 Fix] 프로필 수정 페이지 닉네님 작성 오류 수정 및 글자수 제한 기능 추가 및 프로필 상세페이지 디자인 수정

### DIFF
--- a/moamoa/src/Components/Common/ProfileDetailPost.jsx
+++ b/moamoa/src/Components/Common/ProfileDetailPost.jsx
@@ -79,29 +79,25 @@ export default function ProfileDetailPost() {
         </BtnIcons>
 
         <Views>
-          <HamView>
-            {/* 햄버거 버튼 */}
-            {(view === 'PostList' && userAccountname === 'myInfo') ? (
-              // 조건부 렌더링을 사용하여 내프로필 or 남의 프로필 목록 출력 _ ( 23/11/03/13:50 수정자 : 장수연 )
+          {view === 'PostList' ? (
+            <HamView>
+              {/* 햄버거 버튼 */}
               <ul>
                 {myPostList.map((item) => {
-                  return <PostCardList key={item.id} post={item} />;
+                  // 여기서 myInfo 조건을 확인하여 다른 컴포넌트 렌더링
+                  return userAccountname === 'myInfo' ? (
+                    <PostCardList key={item.id} post={item} />
+                  ) : (
+                    <HomePostCardList key={item.id} post={item} />
+                  );
                 })}
               </ul>
-            ):
+            </HamView>
+          ) : (
+            <BenView>
+              {/* 벤토 버튼 */}
               <ul>
                 {myPostList.map((item) => {
-                  return <HomePostCardList key={item.id} post={item} />;
-                })}
-              </ul>
-            }
-          </HamView>
-          <BenView>
-            {/* 벤토 버튼 */}
-            {view === 'PostImgList' && (
-              <ul>
-                {myPostList.map((item) => {
-                  // 조건부 렌더링을 사용하여 이미지가 없는 경우에는 li를 생성하지 않음
                   return item.image ? (
                     <li onClick={() => handlePostClick(item.id)} key={item.id}>
                       <img src={item.image} alt='Product' />
@@ -109,8 +105,8 @@ export default function ProfileDetailPost() {
                   ) : null;
                 })}
               </ul>
-            )}
-          </BenView>
+            </BenView>
+          )}
         </Views>
       </div>
     </PostListBox>

--- a/moamoa/src/Components/Common/ProfileDetailProduct.jsx
+++ b/moamoa/src/Components/Common/ProfileDetailProduct.jsx
@@ -23,8 +23,8 @@ const ConfirmDelModal = ({ delProduct, closeModal }) => {
     <ConfirmModal>
       <Deltext>정말 삭제하시겠습니까?</Deltext>
       <BtnWrap>
-          <DelBtn onClick={delProduct}>삭제</DelBtn>
-          <CancelBtn onClick={closeModal}>취소</CancelBtn>
+        <DelBtn onClick={delProduct}>삭제</DelBtn>
+        <CancelBtn onClick={closeModal}>취소</CancelBtn>
       </BtnWrap>
     </ConfirmModal>
   );
@@ -51,7 +51,7 @@ function MyProductClick({ productId, closeModal }) {
     const json = await res.json();
     console.log(json);
     closeModal();
-    alert("행사가 삭제되었습니다.")
+    alert('행사가 삭제되었습니다.');
   };
 
   const openConfirmDelModal = () => {
@@ -92,9 +92,9 @@ function MyProductClick({ productId, closeModal }) {
           </BtnProductDesc>
         </section>
       </Modal>
-        {showConfirmDelModal && (
-          <ConfirmDelModal delProduct={delProduct} closeModal={closeConfirmDelModal} />
-        )}
+      {showConfirmDelModal && (
+        <ConfirmDelModal delProduct={delProduct} closeModal={closeConfirmDelModal} />
+      )}
     </ModalCont>
   );
 }
@@ -204,7 +204,11 @@ export default function ProfileDetailProduct() {
                     <ProductBox key={event.id}>
                       <li key={event.id} onClick={() => handleProductClick(event.id)}>
                         <ProductImgBox src={event.itemImage} />
-                        <p className='itemName'>{event.itemName.replace('[f]', '')}</p>
+                        <p className='itemName'>
+                          {event.itemName.slice(0, 3) === '[f]'
+                            ? event.itemName.replace('[f]', '')
+                            : event.itemName.replace('[e]', '')}
+                        </p>
                         <p className='itemDate'>
                           {'행사기간: ' +
                             `${event.price.toString().slice(2, 4)}.${event.price
@@ -216,9 +220,6 @@ export default function ProfileDetailProduct() {
                               .slice(14, 16)}`}
                         </p>
                       </li>
-                      {showMyProductOptions && (
-                        <MyProductClick productId={productId} closeModal={closeModal} />
-                      )}
                     </ProductBox>
                   ))}
                 </ProductListBox>
@@ -356,7 +357,7 @@ const ModalCont = styled.div`
   left: 0;
   top: 0;
   background-color: rgba(0, 0, 0, 0.3);
-  z-index: 10;
+  z-index: 100;
 `;
 
 const Modal = styled.div`
@@ -376,7 +377,6 @@ const Modal = styled.div`
   flex-direction: column;
 `;
 
-
 const Btn = styled.button`
   width: 5rem;
   height: 5rem;
@@ -395,13 +395,13 @@ const BtnDel = styled.button`
   }
 `;
 
-const BtnModify = styled((BtnDel))`
+const BtnModify = styled(BtnDel)`
   color: #4f9ee9;
   border-top: 1px solid #dbdbdb;
   padding-top: 2.5rem;
 `;
 
-const BtnProductDesc = styled((BtnModify))`
+const BtnProductDesc = styled(BtnModify)`
   color: #000;
 `;
 
@@ -441,8 +441,7 @@ const CancelBtn = styled.button`
   }
 `;
 
-const DelBtn = styled(CancelBtn)` 
+const DelBtn = styled(CancelBtn)`
   color: #eb5757;
   border-right: 1px solid #dbdbdb;
 `;
-

--- a/moamoa/src/Pages/Follow/FollowerList.jsx
+++ b/moamoa/src/Pages/Follow/FollowerList.jsx
@@ -7,6 +7,7 @@ import userTokenAtom from '../../Recoil/userTokenAtom';
 import { FollowerAPI } from '../../API/Follow/FollowerAPI';
 import { useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
+import styled from 'styled-components';
 
 export default function FollowerList() {
   const token = useRecoilValue(userTokenAtom);
@@ -32,21 +33,27 @@ export default function FollowerList() {
     <div>
       <Container>
         <HeaderFollwerList />
-        {follower.map((item, index) => {
-          const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
-          return (
-            <FollowUser
-              key={index}
-              src={item.image}
-              userId={cleanedUserId}
-              userText={item.intro}
-              accountname={item.accountname}
-            />
-          );
-        })}
+        <FollowerWrap>
+          {follower.map((item, index) => {
+            const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
+            return (
+              <FollowUser
+                key={index}
+                src={item.image}
+                userId={cleanedUserId}
+                userText={item.intro}
+                accountname={item.accountname}
+              />
+            );
+          })}
+        </FollowerWrap>
 
         <Footer></Footer>
       </Container>
     </div>
   );
 }
+
+const FollowerWrap = styled.div`
+  margin-top: 48px;
+`;

--- a/moamoa/src/Pages/Follow/FollowingList.jsx
+++ b/moamoa/src/Pages/Follow/FollowingList.jsx
@@ -7,6 +7,7 @@ import { useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { FollowingAPI } from '../../API/Follow/FollowingAPI';
 import Footer from '../../Components/Common/Footer';
+import styled from 'styled-components';
 
 export default function FollowingList() {
   const token = useRecoilValue(userTokenAtom);
@@ -31,20 +32,26 @@ export default function FollowingList() {
     <div>
       <Container>
         <HeaderFollowingList />
-        {following.map((item, index) => {
-          const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
-          return (
-            <FollowingUser
-              key={index}
-              src={item.image}
-              userId={cleanedUserId}
-              userText={item.intro}
-              accountname={item.accountname}
-            />
-          );
-        })}
+        <FollowingWrap>
+          {following.map((item, index) => {
+            const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
+            return (
+              <FollowingUser
+                key={index}
+                src={item.image}
+                userId={cleanedUserId}
+                userText={item.intro}
+                accountname={item.accountname}
+              />
+            );
+          })}
+        </FollowingWrap>
         <Footer></Footer>
       </Container>
     </div>
   );
 }
+
+const FollowingWrap = styled.div`
+  margin-top: 48px;
+`;

--- a/moamoa/src/Pages/Home/HomeFeed.jsx
+++ b/moamoa/src/Pages/Home/HomeFeed.jsx
@@ -4,14 +4,19 @@ import homeBg from '../../Assets/icons/character-yellow.png';
 import { useNavigate } from 'react-router-dom';
 
 export default function HomeFeed() {
-
   const navigate = useNavigate();
 
   return (
     <UserSearchHome>
       <HomeCont>
         <SearchText>유저를 검색해 팔로우 해보세요!</SearchText>
-        <SearchBtn onClick={()=> {navigate('/search')}}>검색하기</SearchBtn>
+        <SearchBtn
+          onClick={() => {
+            navigate('/search');
+          }}
+        >
+          검색하기
+        </SearchBtn>
       </HomeCont>
     </UserSearchHome>
   );
@@ -20,7 +25,7 @@ const UserSearchHome = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-
+  background-color: #fff;
 `;
 const HomeCont = styled.div`
   position: relative;

--- a/moamoa/src/Pages/Product/ProductList.jsx
+++ b/moamoa/src/Pages/Product/ProductList.jsx
@@ -48,85 +48,87 @@ export default function ProductList() {
   return (
     <ContainerPercent>
       <Header />
-      <Nav>
-        <FestivalBtn isActive={isFestivalActive} onClick={toggleFestival}>
-          축제
-        </FestivalBtn>
-        <ExperienceBtn isActive={isExperienceActive} onClick={toggleExperience}>
-          체험
-        </ExperienceBtn>
-      </Nav>
-      {loading ? (
-        <p>Loading...</p>
-      ) : error ? (
-        <p>Error:{error.message}</p>
-      ) : (
-        <ProductContainer>
-          {isFestivalActive
-            ? product
+      <ProductListWrap>
+        <Nav>
+          <FestivalBtn isActive={isFestivalActive} onClick={toggleFestival}>
+            축제
+          </FestivalBtn>
+          <ExperienceBtn isActive={isExperienceActive} onClick={toggleExperience}>
+            체험
+          </ExperienceBtn>
+        </Nav>
+        {loading ? (
+          <p>Loading...</p>
+        ) : error ? (
+          <p>Error:{error.message}</p>
+        ) : (
+          <ProductContainer>
+            {isFestivalActive
+              ? product
 
-                .filter((item) => {
-                  if (item.price.toString().length >= 16) {
-                    return true;
-                  }
-                  return false;
-                })
-                .filter((item) => {
-                  return item.itemName.includes('[f]');
-                })
-                .map((item, index) => (
-                  <ProductBox key={index}>
-                    <Link to={`/product/detail/${item._id}`} key={index}>
-                      <ProductImgBox src={item.itemImage} />
-                    </Link>
-                    <p className='itemName'>{item.itemName.replace('[f]', '')}</p>
-                    <p className='itemDate'>
-                      {'행사기간: ' +
-                        `${item.price.toString().slice(2, 4)}.${item.price
-                          .toString()
-                          .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
-                          .toString()
-                          .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
-                          .toString()
-                          .slice(14, 16)}`}
-                    </p>
-                  </ProductBox>
-                ))
-            : null}
-          {/* {console.log('콘솔로그는 뭘까:', product)} */}
-          {/* {console.log('아이디찾기:', product[0]._id)} */}
-          {isExperienceActive
-            ? product
-                .filter((item) => {
-                  if (item.price.toString().length >= 16) {
-                    return true;
-                  }
-                  return false;
-                })
-                .filter((item) => {
-                  return item.itemName.includes('[e]');
-                })
-                .map((item, index) => (
-                  <ProductBox key={index}>
-                    <Link to={`/product/detail/${item._id}`} key={index}>
-                      <ProductImgBox src={item.itemImage} />
-                    </Link>
-                    <p className='itemName'>{item.itemName.replace('[e]', '')}</p>
-                    <p className='itemDate'>
-                      {'행사기간: ' +
-                        `${item.price.toString().slice(2, 4)}.${item.price
-                          .toString()
-                          .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
-                          .toString()
-                          .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
-                          .toString()
-                          .slice(14, 16)}`}
-                    </p>
-                  </ProductBox>
-                ))
-            : null}
-        </ProductContainer>
-      )}
+                  .filter((item) => {
+                    if (item.price.toString().length >= 16) {
+                      return true;
+                    }
+                    return false;
+                  })
+                  .filter((item) => {
+                    return item.itemName.includes('[f]');
+                  })
+                  .map((item, index) => (
+                    <ProductBox key={index}>
+                      <Link to={`/product/detail/${item._id}`} key={index}>
+                        <ProductImgBox src={item.itemImage} />
+                      </Link>
+                      <p className='itemName'>{item.itemName.replace('[f]', '')}</p>
+                      <p className='itemDate'>
+                        {'행사기간: ' +
+                          `${item.price.toString().slice(2, 4)}.${item.price
+                            .toString()
+                            .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
+                            .toString()
+                            .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
+                            .toString()
+                            .slice(14, 16)}`}
+                      </p>
+                    </ProductBox>
+                  ))
+              : null}
+            {/* {console.log('콘솔로그는 뭘까:', product)} */}
+            {/* {console.log('아이디찾기:', product[0]._id)} */}
+            {isExperienceActive
+              ? product
+                  .filter((item) => {
+                    if (item.price.toString().length >= 16) {
+                      return true;
+                    }
+                    return false;
+                  })
+                  .filter((item) => {
+                    return item.itemName.includes('[e]');
+                  })
+                  .map((item, index) => (
+                    <ProductBox key={index}>
+                      <Link to={`/product/detail/${item._id}`} key={index}>
+                        <ProductImgBox src={item.itemImage} />
+                      </Link>
+                      <p className='itemName'>{item.itemName.replace('[e]', '')}</p>
+                      <p className='itemDate'>
+                        {'행사기간: ' +
+                          `${item.price.toString().slice(2, 4)}.${item.price
+                            .toString()
+                            .slice(4, 6)}.${item.price.toString().slice(6, 8)}~${item.price
+                            .toString()
+                            .slice(10, 12)}.${item.price.toString().slice(12, 14)}.${item.price
+                            .toString()
+                            .slice(14, 16)}`}
+                      </p>
+                    </ProductBox>
+                  ))
+              : null}
+          </ProductContainer>
+        )}
+      </ProductListWrap>
       <Footer></Footer>
     </ContainerPercent>
   );
@@ -135,8 +137,11 @@ export default function ProductList() {
 const Nav = styled.div`
   /* display: flex; */
   padding: 12px;
-  padding-left: 18px;
   /* height: 100vh; */
+`;
+
+const ProductListWrap = styled.div`
+  margin-top: 48px;
 `;
 const Button = styled.button`
   width: 80px;

--- a/moamoa/src/Pages/Profile/EditProfile.jsx
+++ b/moamoa/src/Pages/Profile/EditProfile.jsx
@@ -22,10 +22,16 @@ function EditProfile() {
   const token = useRecoilValue(userToken);
   const navigate = useNavigate();
 
-  const [initUsername, setInitUsername] = useState('');
-  const [initAccountname, setInitAccountname] = useState('');
-  const [initIntron, setInitIntron] = useState('');
-  const [initImgSrc, setInitImgSrc] = useState(''); // 이미 있는 이미지 주소
+  const [username, setUsername] = useState('');
+  const [accountname, setAccountname] = useState('');
+  const [imgSrc, setImgSrc] = useState('');
+  const [intro, setIntro] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [accountError, setAccountError] = useState('');
+  const [duplicateIdError, setDuplicateIdError] = useState('');
+  const [userNameError, setUserNameError] = useState('');
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+  const [userType, setUserType] = useState('');
 
   // 내 정보 API
   const getInitInfo = async () => {
@@ -40,16 +46,14 @@ function EditProfile() {
     console.log(json);
 
     if (json && json.user) {
-      setInitImgSrc(json.user['image'] || '');
       setImgSrc(json.user['image'] || '');
 
-      setInitAccountname(json.user['accountname'] || '');
-      setAccountname(json.user['accountname'] || '');
+      setAccountname(json.user['accountname']);
 
-      setInitUsername(json.user['username'] || '');
-      setUsername(json.user['username'] || '');
+      setUserType(json.user['username'].slice(0, 3));
 
-      setInitIntron(json.user['intro'] || '');
+      setUsername(json.user['username'].slice(3, json.user['username'].length) || '');
+
       setIntro(json.user['intro'] || '');
     }
   };
@@ -58,17 +62,6 @@ function EditProfile() {
     // 컴포넌트가 마운트될 때 getInitInfo 함수를 실행합니다.
     getInitInfo();
   }, []);
-
-  const [username, setUsername] = useState(initUsername);
-  const [accountname, setAccountname] = useState(initAccountname);
-  const [imgSrc, setImgSrc] = useState(initImgSrc);
-  const [intro, setIntro] = useState(initIntron);
-  const [errorMessage, setErrorMessage] = useState('');
-  const [accountError, setAccountError] = useState('');
-  const [duplicateIdError, setDuplicateIdError] = useState('');
-  const [userNameError, setUserNameError] = useState('');
-  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
-
   // 프로필 수정 API
   const edit = async (editData) => {
     // const token = localStorage.getItem('token');
@@ -162,9 +155,11 @@ function EditProfile() {
   const submitEdit = (e) => {
     e.preventDefault();
 
+    const fullUsername = userType + username;
+
     const editData = {
       user: {
-        username: username,
+        username: fullUsername,
         accountname: accountname,
         intro: intro,
         image: imgSrc,
@@ -206,7 +201,7 @@ function EditProfile() {
           {/* 프로필 이미지 */}
           <ProfileImg>
             <label htmlFor='profileImg'>
-              <img src={imgSrc || initImgSrc} alt='Profile' id='imagePre' />
+              <img src={imgSrc} alt='Profile' id='imagePre' />
               <img src={uploadFile} alt='' />
             </label>
             <input

--- a/moamoa/src/Pages/Profile/EditProfile.jsx
+++ b/moamoa/src/Pages/Profile/EditProfile.jsx
@@ -28,6 +28,8 @@ function EditProfile() {
   const [intro, setIntro] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
   const [accountError, setAccountError] = useState('');
+  const [accountLengthError, setAccountLengthError] = useState('');
+  const [introError, setIntroError] = useState('');
   const [duplicateIdError, setDuplicateIdError] = useState('');
   const [userNameError, setUserNameError] = useState('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
@@ -89,8 +91,11 @@ function EditProfile() {
     const pattern = /^[a-zA-Z0-9._]+$/; // 영문, 숫자, ., _ 만 허용
     if (!pattern.test(value)) {
       setAccountError('영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.');
+    } else if (value.length < 2 || value.length > 15) {
+      setAccountLengthError('2~15자 이내여야 합니다.');
     } else {
       setAccountError('');
+      setAccountLengthError('');
     }
   };
 
@@ -99,6 +104,14 @@ function EditProfile() {
       setUserNameError('사용자 이름은 2~10자 이내여야 합니다.');
     } else {
       setUserNameError('');
+    }
+  };
+
+  const validateIntroLength = (value) => {
+    if (value.length < 2 || value.length > 50) {
+      setIntroError('2~50자 이내여야 합니다.');
+    } else {
+      setIntroError('');
     }
   };
 
@@ -115,6 +128,7 @@ function EditProfile() {
   };
   const inputInfo = (e) => {
     setIntro(e.target.value);
+    validateIntroLength(e.target.value);
   };
 
   const uploadImage = async (imageFile) => {
@@ -173,6 +187,8 @@ function EditProfile() {
     const isAllValid =
       !userNameError &&
       !accountError &&
+      !introError &&
+      !accountLengthError &&
       !duplicateIdError &&
       username &&
       accountname &&
@@ -181,7 +197,17 @@ function EditProfile() {
 
     // 상태 변수 업데이트
     setIsButtonDisabled(!isAllValid);
-  }, [userNameError, accountError, duplicateIdError, username, accountname, imgSrc, intro]);
+  }, [
+    userNameError,
+    accountError,
+    accountLengthError,
+    introError,
+    duplicateIdError,
+    username,
+    accountname,
+    imgSrc,
+    intro,
+  ]);
 
   const handleFormSubmit = (e) => {
     e.preventDefault();
@@ -250,6 +276,7 @@ function EditProfile() {
               </TextInput>
               {duplicateIdError && <EorrorMsg>{duplicateIdError}</EorrorMsg>}
               {accountError && <EorrorMsg>{accountError}</EorrorMsg>}
+              {accountLengthError && <EorrorMsg>{accountLengthError}</EorrorMsg>}
             </div>
             <div>
               <TextLabel>
@@ -266,6 +293,7 @@ function EditProfile() {
                   required
                 />
               </TextInput>
+              {introError && <EorrorMsg>{introError}</EorrorMsg>}
             </div>
           </EditProfileBox>
         </form>

--- a/moamoa/src/Pages/Profile/MyProfile.jsx
+++ b/moamoa/src/Pages/Profile/MyProfile.jsx
@@ -24,7 +24,8 @@ import HeaderKebab from '../../Components/Common/HeaderKebab';
 function MyProfile() {
   const navigate = useNavigate();
 
-  const userType = useRecoilValue(userNameAtom).includes('[o]') ? 'organization' : 'Individual';
+  const userType =
+    useRecoilValue(userNameAtom).slice(0, 3) === '[o]' ? 'organization' : 'Individual';
 
   console.log(`userType : ${userType}`);
 

--- a/moamoa/src/Pages/Profile/YourProfile.jsx
+++ b/moamoa/src/Pages/Profile/YourProfile.jsx
@@ -27,7 +27,8 @@ import HeaderKebab from '../../Components/Common/HeaderKebab';
 function YourProfile() {
   const navigate = useNavigate();
 
-  const userType = useRecoilValue(userNameAtom).includes('[o]') ? 'organization' : 'Individual';
+  const userType =
+    useRecoilValue(userNameAtom).slice(0, 3) === '[o]' ? 'organization' : 'Individual';
   console.log(userType);
   // 현제 페이지 주소 복사
   function copyURLToClipboard() {


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
- position: fixed 추가로 발생한 레이아웃 이슈 해결 : 팔로잉 리스트, 팔로우 리스트, 축제목록 페이지
- homefeed 페이지에 흰색 배경 추가
- 프로필 수정 페이지에서 발생한 이슈 해결
- 프로필 수정 페이지에 계정 id와 소개글의 글자수 제한을 추가
- 프로필 상세 페이지 상품 리스트에서 축제일 경우 [e]가 노출되는 문제 해결
- 프로필 상세 페이지에서 조건부 렌더링을 사용하여 이미지가 없는 경우에는 li를 생성하지 않는 기능을 추가한 뒤 발생한 오류를 해결

### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
프로필 수정 페이지
- 게정 id는 2 ~ 15자의 글자 수 제한을, 소개글은 2 ~ 50자의 글자수 제한을 추가했습니다.
- 판매자/개인 계정을 구분하기 위해 추가한 [o]/[i]가 프로필 수정 페이지에 그대로 노출되며 사용자가 직접 [o]/[i]를 입력하였을때 판매자/개인 계정으로 바뀌는 문제를 해결했습니다.

프로필 상세 페이지
- 상품 리스트에서 축제일 경우 [e]가 노출되는 문제를 해결했습니다.
-  조건부 렌더링을 사용하여 이미지가 없는 경우에는 li를 생성하지 않는 기능을 추가한 뒤에 발생한 벤토 버튼을 클릭하였을 때 목록형 게시글도 출력되는 문제를 해결했습니다.


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
계획
- 팔로우/언팔로우 버튼 기능 이슈 해결


### 특이 사항 :
Issue Number #181 
