### PR TITLE
[🔧 Fix] 다른 화면에서 로그인 화면으로 이동 시 local storage에 값이 남아있는 문제

### DIFF
--- a/moamoa/src/API/Post/PostDetailAPI.jsx
+++ b/moamoa/src/API/Post/PostDetailAPI.jsx
@@ -1,27 +1,25 @@
 export default function PostDetailAPI(token, post_id, getPostDetail) {
+  const getPostInfo = async () => {
+    const reqUrl = `https://api.mandarin.weniv.co.kr/post/${post_id}`;
 
-    const getPostInfo = async () => {
-      const reqUrl = `https://api.mandarin.weniv.co.kr/post/${post_id}`;
+    try {
+      const res = await fetch(reqUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-type': 'application/json',
+        },
+      });
 
-      try {
-        const res = await fetch(reqUrl, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-type': 'application/json',
-          },
-        });
-
-        if (res.status === 200) {
-          const data = await res.json();
-          await getPostDetail({...data})
-        } else {
-          console.error('페이지를 불러오는데 실패했습니다.');
-        }
-      } catch (error) {
-        console.error('서버와 통신을 실패했습니다.', error);
+      if (res.status === 200) {
+        const data = await res.json();
+        await getPostDetail({ ...data });
+      } else {
+        console.error('페이지를 불러오는데 실패했습니다.');
       }
-
-    };
-
-    return getPostInfo;
+    } catch (error) {
+      console.error('서버와 통신을 실패했습니다.', error);
+    }
+  };
+  return getPostInfo;
+}

--- a/moamoa/src/Hooks/Sign/useLogin.jsx
+++ b/moamoa/src/Hooks/Sign/useLogin.jsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import LoginAPI from '../../API/Auth/LoginAPI';
 import userTokenAtom from '../../Recoil/userTokenAtom';
 import isLoginAtom from '../../Recoil/isLoginAtom';
 import accountNameAtom from '../../Recoil/accountNameAtom';
 import userNameAtom from '../../Recoil/userNameAtom';
+import followPostAtom from '../../Recoil/followPostAtom';
 
 const useLogin = () => {
   const navigate = useNavigate();
@@ -18,10 +19,19 @@ const useLogin = () => {
     },
   });
 
-  const setUserToken = useSetRecoilState(userTokenAtom);
-  const setIsLoginState = useSetRecoilState(isLoginAtom);
-  const setAccountName = useSetRecoilState(accountNameAtom);
-  const setUserName = useSetRecoilState(userNameAtom);
+  const [userToken, setUserToken] = useRecoilState(userTokenAtom);
+  const [isLoginState, setIsLoginState] = useRecoilState(isLoginAtom);
+  const [accountName, setAccountName] = useRecoilState(accountNameAtom);
+  const [userName, setUserName] = useRecoilState(userNameAtom);
+  const [followPost, setFollowPost] = useRecoilState(followPostAtom);
+
+  useEffect(() => {
+    userToken && setUserToken('');
+    isLoginState && setIsLoginState(false);
+    accountName && setAccountName('');
+    userName && setUserName('');
+    followPost && setFollowPost([]);
+  }, []);
 
   const handleError = () => {
     const user = userInput.user;


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 로그인 성공 후 홈 화면으로 이동, 뒤로 가기 클릭 시 로그인 화면으로 이동이 가능합니다.
+ 로그아웃 하지 않은 상황에서 로그인 화면으로 이동 가능이 가능합니다.
+ 위 상황 모두 로그인 했을 당시 local storage 값이 그대로 저장되어 있어 이를 초기화하는 작업 진행합니다.




### 작업 내역
- [x] 로그인 페이지가 마운트되었을 때 local storage에 값(accountNameAtom, followPostAtom, isLoginAtom, userNameAtom, userTokenAtom)이 있다면 초기화합니다.



### 작업 후 기대 동작(스크린샷) 
+ 로그인 후 홈에서 뒤로 가기, 로그인 페이지로 이동 (왼쪽: 수정 전, 오른쪽: 수정 후)   

![수정 전](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/9d868ba0-bf88-4bcf-94b5-9ce052c1b3cc) |![수정 이후](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/ac5f1371-d951-4566-8904-cafbe44842fc)
--- | --- | 




### PR 특이 사항
+ PostDetailAPI '}' expected 에러 수정합니다.



### 특이 사항 :
Issue Number

close: # 207
