### PR TITLE
[ 🔧Fix ] 게시글 상단 유저 프로필 이동 경로 수정

### DIFF
--- a/moamoa/src/Components/Comment/AddCommentBtn.jsx
+++ b/moamoa/src/Components/Comment/AddCommentBtn.jsx
@@ -25,5 +25,6 @@ const AddBtn = styled.button`
 
 const AddBtnOn = styled(AddBtn)`
   background-color: #87B7E4;
+  border: 1px solid #87B7E4;
   color: white;
 `;

--- a/moamoa/src/Components/Common/ProfileDetailProduct.jsx
+++ b/moamoa/src/Components/Common/ProfileDetailProduct.jsx
@@ -356,7 +356,7 @@ const ModalCont = styled.div`
   left: 0;
   top: 0;
   background-color: rgba(0, 0, 0, 0.3);
-  z-index: 10;
+  z-index: 100;
 `;
 
 const Modal = styled.div`

--- a/moamoa/src/Components/Home/HomePostCardList.jsx
+++ b/moamoa/src/Components/Home/HomePostCardList.jsx
@@ -8,68 +8,51 @@ import heartBgFill from '../../Assets/icons/heart-fill.svg';
 import commentBg from '../../Assets/icons/message-circle.svg';
 import Datacalc from '../Common/datecalc';
 
-import userTokenAtom from '../../Recoil/userTokenAtom';
+import HeartCountDownAPI from '../../API/Post/HeartCountDownAPI';
+import HeartCountUpAPI from '../../API/Post/HeartCountUpAPI';
+import accountNameAtom from '../../Recoil/accountNameAtom'; 
 import { useRecoilValue } from 'recoil';
 
+
 export default function HomePostCardList(post) {
-  const token = useRecoilValue(userTokenAtom);
-
-  const postItem = post.post;
-  const profileImgUrl = `${postItem.author.image}`;
-  const postImgUrl = `${postItem.image}`;
-  const postDetailId = post.post.id;
-  const postDetailUrl = `/post/${postDetailId}`;
   
-  const [heartValue, setHeartValue] = useState(postItem.hearted);
+  const accountAtom = useRecoilValue(accountNameAtom);
+
+  const postInfo = post.post;
+  const postAuthorInfo = postInfo.author;
+  const profileImgUrl = `${postAuthorInfo.image}`;
+  const postImgUrl = `${postInfo.image}`;
+  const postId = post.post.id;
+  const postDetailUrl = `/post/${postId}`;
+  
+  const [heartValue, setHeartValue] = useState(postInfo.hearted);
   const [heartcolor, setHeartColor] = useState(heartBg);
-  const [heartcount, setHeartCount] = useState(postItem.heartCount);
+  const [heartcount, setHeartCount] = useState(postInfo.heartCount);
 
-  const heartPost = async () => {
-    try {
-      const response = await fetch(`https://api.mandarin.weniv.co.kr/post/${postDetailId}/heart`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      });
-      const data = await response.json();
-      console.log(data);
-      return data;
-      
-    } catch (error) {
-      console.error('API 응답에 실패하였습니다.', error);
-    }
-  };
+  const heartPost = HeartCountUpAPI(postId)
 
-const unheartPost = async () => {
-    try {
-      const response = await fetch(`https://api.mandarin.weniv.co.kr/post/${postDetailId}/unheart`, {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      });
-      const data = await response.json();
-      console.log(data);
-      return data;
-    } catch (error) {
-      console.error('API 응답에 실패하였습니다.', error);
-    }
-  };
+  const hearted = async () => {
+      await heartPost();
+  }
+
+  const ununheartPost = HeartCountDownAPI(postId)
+
+  const unhearted = async () => {
+      await ununheartPost();
+  }
+
   
   const handleHeartCount = () => {
       setHeartColor(heartBgFill);
       setHeartCount((prev)=>prev + 1);
       setHeartValue((prev)=>!prev)
-      heartPost();
+      hearted();
   };
 
   const handleUnheartCount = () => {
     setHeartCount((prev)=>prev -1)
     setHeartValue((prev)=>!prev)
-    unheartPost()
+    unhearted()
     setHeartColor(heartBg);
   }
 
@@ -81,17 +64,18 @@ const unheartPost = async () => {
             <Frofile>
               <PostCardUser
                 url={profileImgUrl}
-                username={postItem.author.username.slice(3)}
-                accountname={postItem.author.accountname}
+                username={postAuthorInfo.username.slice(3)}
+                accountname={postAuthorInfo.accountname}
+                loginAccountName={accountAtom}
               />
-              <HomePostMoreBtn postid={post.post.id}/>
+              <HomePostMoreBtn postid={postId}/>
             </Frofile>
             <Link to={postDetailUrl}>
-              <PostDesc>{postItem.content}</PostDesc>
+              <PostDesc>{postInfo.content}</PostDesc>
               {postImgUrl ? <PostImg src={postImgUrl} alt='게시글 사진' /> : null}
             </Link>
             <PostFooterContainer>
-              <CreateDate>{Datacalc(postItem.createdAt)}</CreateDate>
+              <CreateDate>{Datacalc(postInfo.createdAt)}</CreateDate>
               <div>
 
                 { heartValue ? <HeartBtn
@@ -110,7 +94,7 @@ const unheartPost = async () => {
                 </HeartBtn>}
 
                 <Link to={postDetailUrl}>
-                  <CommentBtn>{postItem.commentCount}</CommentBtn>
+                  <CommentBtn>{postInfo.commentCount}</CommentBtn>
                 </Link>
               </div>
             </PostFooterContainer>

--- a/moamoa/src/Components/Modal/ReportModal.jsx
+++ b/moamoa/src/Components/Modal/ReportModal.jsx
@@ -14,11 +14,6 @@ ReportModal.propTypes = {
 }
 
 export default function ReportModal({closemodal, setclosemodal,postid}) {
-console.log(closemodal)
-
-      {console.log(postid)}
-
-
   
   const token = useRecoilValue(userTokenAtom);
   const params = useParams();

--- a/moamoa/src/Components/Post/PostCardItem.jsx
+++ b/moamoa/src/Components/Post/PostCardItem.jsx
@@ -69,7 +69,7 @@ export default function PostCardDetail({post}) {
             <Frofile>
               <PostCardUser url={postAuthorInfo.image}
                 username={postAuthorInfo.username.slice(3)}
-                accountname={accountName}
+                accountname={accountName} loginAccountName={accountAtom}
               />
               {accountAtom === accountName ? <MyPostMoreBtn
                 accountname={accountName}

--- a/moamoa/src/Components/Post/PostCardList.jsx
+++ b/moamoa/src/Components/Post/PostCardList.jsx
@@ -7,67 +7,49 @@ import heartBg from '../../Assets/icons/heart.svg';
 import heartBgFill from '../../Assets/icons/heart-fill.svg';
 import commentBg from '../../Assets/icons/message-circle.svg';
 import Datacalc from '../Common/datecalc';
-import userTokenAtom from '../../Recoil/userTokenAtom';
+import HeartCountDownAPI from '../../API/Post/HeartCountDownAPI';
+import HeartCountUpAPI from '../../API/Post/HeartCountUpAPI';
+import accountNameAtom from '../../Recoil/accountNameAtom'; 
 import { useRecoilValue } from 'recoil';
 
 export default function PostCardList(post) {
+
+  const accountAtom = useRecoilValue(accountNameAtom);
   const [showModal, setShowModal] = useState(false);
   const postItem = post.post;
-  const profileImgUrl = `${postItem.author.image}`;
+  const postAuthorInfo = postItem.author;
+  const profileImgUrl = `${postAuthorInfo.image}`;
   const postImgUrl = `${postItem.image}`;
   const postId = postItem.id;
   const postDetailUrl = `/post/${postId}`;
-  const token = useRecoilValue(userTokenAtom);
 
   const [heartValue, setHeartValue] = useState(postItem.hearted);
   const [heartcolor, setHeartColor] = useState(heartBg);
   const [heartcount, setHeartCount] = useState(postItem.heartCount);
 
-  const heartPost = async () => {
-    try {
-      const response = await fetch(`https://api.mandarin.weniv.co.kr/post/${postId}/heart`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      });
-      const data = await response.json();
-      console.log(data);
-      return data;
-    } catch (error) {
-      console.error('API 응답에 실패하였습니다.', error);
-    }
-  };
+  const heartPost = HeartCountUpAPI(postId)
 
-  const unheartPost = async () => {
-    try {
-      const response = await fetch(`https://api.mandarin.weniv.co.kr/post/${postId}/unheart`, {
-        method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-type': 'application/json',
-        },
-      });
-      const data = await response.json();
-      console.log(data);
-      return data;
-    } catch (error) {
-      console.error('API 응답에 실패하였습니다.', error);
-    }
-  };
+  const hearted = async () => {
+      await heartPost();
+  }
+
+  const ununheartPost = HeartCountDownAPI(postId)
+
+  const unhearted = async () => {
+      await ununheartPost();
+  }
 
   const handleHeartCount = () => {
     setHeartColor(heartBgFill);
     setHeartCount((prev) => prev + 1);
     setHeartValue((prev) => !prev);
-    heartPost();
+    hearted();
   };
 
   const handleUnheartCount = () => {
     setHeartCount((prev) => prev - 1);
     setHeartValue((prev) => !prev);
-    unheartPost();
+    unhearted();
     setHeartColor(heartBg);
   };
 
@@ -79,13 +61,14 @@ export default function PostCardList(post) {
             <Frofile>
               <PostCardUser
                 url={profileImgUrl}
-                username={postItem.author.username.slice(3)}
-                accountname={postItem.author.accountname}
+                username={postAuthorInfo.username.slice(3)}
+                accountname={postAuthorInfo.accountname}
+                loginAccountName={accountAtom}
               />
 
               <MyPostMoreBtn
                 postid={postId}
-                accountname={postItem.author.accountname}
+                accountname={postAuthorInfo.accountname}
                 onClick={() => {
                   setShowModal(true);
                   console.log(showModal);

--- a/moamoa/src/Components/Post/PostCardUser.jsx
+++ b/moamoa/src/Components/Post/PostCardUser.jsx
@@ -6,14 +6,19 @@ import { Link } from 'react-router-dom';
 PostCardUser.propTypes = {
   url: PropTypes.string,
   username: PropTypes.string,
-  accountname: PropTypes.string
+  accountname: PropTypes.string,
+  loginAccountName: PropTypes.string
 }
 
-export default function PostCardUser({url, username, accountname }) {
+export default function PostCardUser({url, username, accountname, loginAccountName }) {
   return (
     <Container>
         <>
-          <Link to={`/profile/${accountname}`}>
+          <Link to={ 
+            loginAccountName === accountname ? 
+            `/profile/myInfo`
+            : `/profile/${accountname}`
+          }>
             <UserInfo>
               <FrofileImg src={url} alt="사용자프로필"/>        
               <InfoText>

--- a/moamoa/src/Pages/Product/AskBtn.jsx
+++ b/moamoa/src/Pages/Product/AskBtn.jsx
@@ -2,11 +2,19 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import { useNavigate, useParams } from 'react-router-dom';
-import userNameAtom from '../../Recoil/userNameAtom';
+import accountNameAtom from '../../Recoil/accountNameAtom';
 import DeleteModal from '../../Components/Modal/DeleteModal';
+import PropTypes from 'prop-types';
 
-export default function AskBtn(username) {
-  const userName = useRecoilValue(userNameAtom);
+AskBtn.propTypes = {
+  accountname: PropTypes.string,
+  userName: PropTypes.string
+}
+
+
+export default function AskBtn({accountname, userName}) {
+
+  const loginAccountName = useRecoilValue(accountNameAtom);
   const [showModal, setShowModal] = useState(true);
 
   const navigate = useNavigate();
@@ -15,15 +23,13 @@ export default function AskBtn(username) {
   const handleBtnClick = () => {
     navigate('/product/edit', { state: params });
   };
-  const chatUserName = username.username;
   const handleChatRoom = () => {
-    navigate(`/chat/${chatUserName}`);
+    navigate(`/chat/${userName}`);
   };
-  console.log(chatUserName);
   return (
     <>
-      {username.username !== userName ? (
-        <Ask chatUserName={chatUserName} onClick={handleChatRoom}>
+      {accountname !== loginAccountName ? (
+        <Ask onClick={handleChatRoom}>
           문의하기
         </Ask>
       ) : (

--- a/moamoa/src/Pages/Product/ProductDetail.jsx
+++ b/moamoa/src/Pages/Product/ProductDetail.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import Header from '../../Components/Common/HeaderBasic';
 import AskBtn from './AskBtn';
 import PostCardUser from '../../Components/Post/PostCardUser';
+import Footer from '../../Components/Common/Footer';
 
 export default function ProductDetail() {
   const productState = atom({
@@ -81,7 +82,7 @@ export default function ProductDetail() {
                     username={productData.product[pageIndex].author.username.slice(3)}
                     accountname={productData.product[pageIndex].author.accountname}
                   />
-                  <AskBtn username={productData.product[pageIndex].author.username} />
+                  <AskBtn accountname={productData.product[pageIndex].author.accountname} userName={productData.product[pageIndex].author.username.slice(3)} />
                 </Frofile>
                 <FestivalImg src={productData.product[pageIndex]?.itemImage || ''} alt='행사' />
                 <InfoContainer>
@@ -101,6 +102,7 @@ export default function ProductDetail() {
                   </FestivalDesc>
                 </InfoContainer>
               </FestivalWrap>
+              <Footer />
             </FestivalContainer>
           </Container>
         </>


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
게시글 상단 유저 프로필 클릭 시 내 프로필의 경로가 myInfo가 아닌 계정명으로 이동하게 되는 문제가있었고 이 문제로 인해 내가 쓴 게시글의 더보기 버튼을 눌렀을때 신고하기 모달이 활성화 되는 문제가 추가로발생했습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
로그인한 accountname이 게시글 작성자의 accountname과 같을경우 myInfo 페이지로 이동하게 경로를 수정했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number

close: # 자기가 개발 전에 올린 이슈
