### PR TITLE
[🔧fix]검색 페이지 검색 내용을 지우면 안내문구, 로딩 이미지 추가

### DIFF
--- a/moamoa/src/Components/Common/HeaderChat.jsx
+++ b/moamoa/src/Components/Common/HeaderChat.jsx
@@ -22,7 +22,7 @@ export default function HeaderChat(props) {
 const HeaderChatRoom = styled.div`
   display: flex;
   height: 48px;
-  /* position: fixed; */
+
   min-height: 48px;
   max-height: 48px;
   width: 390px;

--- a/moamoa/src/Pages/Search/Loader.jsx
+++ b/moamoa/src/Pages/Search/Loader.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+const spin = keyframes`
+  0% { opacity: 1 }
+  100% { opacity: 0 }
+`;
+
+const Container = styled.div`
+  width: 200px;
+  height: 200px;
+  display: inline-block;
+  overflow: hidden;
+  background: #ffffff;
+  margin: 50px auto;
+`;
+
+const Spinner = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform: translateZ(0) scale(1);
+  backface-visibility: hidden;
+  transform-origin: 0 0;
+`;
+
+const SpinnerDiv = styled.div`
+  left: 94px;
+  top: 48px;
+  position: absolute;
+  animation: ${spin} linear 1s infinite;
+  background: #767676;
+  width: 12px;
+  height: 24px;
+  border-radius: 6px / 12px;
+  transform-origin: 6px 52px;
+  margin: 0 auto;
+
+  &:nth-child(1) {
+    transform: rotate(0deg);
+    animation-delay: -0.9166666666666666s;
+    background: #767676;
+  }
+  &:nth-child(2) {
+    transform: rotate(30deg);
+    animation-delay: -0.8333333333333334s;
+    background: #767676;
+  }
+  &:nth-child(3) {
+    transform: rotate(60deg);
+    animation-delay: -0.75s;
+    background: #767676;
+  }
+  &:nth-child(4) {
+    transform: rotate(90deg);
+    animation-delay: -0.6666666666666666s;
+    background: #767676;
+  }
+  &:nth-child(5) {
+    transform: rotate(120deg);
+    animation-delay: -0.5833333333333334s;
+    background: #767676;
+  }
+  &:nth-child(6) {
+    transform: rotate(150deg);
+    animation-delay: -0.5s;
+    background: #767676;
+  }
+  &:nth-child(7) {
+    transform: rotate(180deg);
+    animation-delay: -0.4166666666666667s;
+    background: #767676;
+  }
+  &:nth-child(8) {
+    transform: rotate(210deg);
+    animation-delay: -0.3333333333333333s;
+    background: #767676;
+  }
+  &:nth-child(9) {
+    transform: rotate(240deg);
+    animation-delay: -0.25s;
+    background: #767676;
+  }
+  &:nth-child(10) {
+    transform: rotate(270deg);
+    animation-delay: -0.16666666666666666s;
+    background: #767676;
+  }
+  &:nth-child(11) {
+    transform: rotate(300deg);
+    animation-delay: -0.08333333333333333s;
+    background: #767676;
+  }
+  &:nth-child(12) {
+    transform: rotate(330deg);
+    animation-delay: 0s;
+    background: #767676;
+  }
+`;
+
+const Loader = () => {
+  return (
+    <Container>
+      <Spinner>
+        {[...Array(12)].map((_, index) => (
+          <SpinnerDiv key={index}></SpinnerDiv>
+        ))}
+      </Spinner>
+    </Container>
+  );
+};
+
+export default Loader;

--- a/moamoa/src/Pages/Search/Search.jsx
+++ b/moamoa/src/Pages/Search/Search.jsx
@@ -30,7 +30,6 @@ export default function Search() {
       try {
         const result = await SearchAPI(token, debounceValue);
         if (!cancel) {
-          // 취소되지 않았을 때에만 결과 업데이트
           setSearchResults(result);
           setIsLoading(false);
         }

--- a/moamoa/src/Pages/Search/Search.jsx
+++ b/moamoa/src/Pages/Search/Search.jsx
@@ -10,7 +10,7 @@ import useDebounce from '../../Hooks/Search/useDebounce';
 import { useNavigate } from 'react-router-dom';
 import SearchHighLight from '../../Components/Common/SearchHighLight';
 import iconSearchNotFound from '../../Assets/icons/icon-searchNotFound.svg';
-/* eslint-disable */
+
 import Loader from './Loader';
 export default function Search() {
   const [searchText, setSearchText] = useState('');

--- a/moamoa/src/Pages/Search/Search.jsx
+++ b/moamoa/src/Pages/Search/Search.jsx
@@ -10,6 +10,8 @@ import useDebounce from '../../Hooks/Search/useDebounce';
 import { useNavigate } from 'react-router-dom';
 import SearchHighLight from '../../Components/Common/SearchHighLight';
 import iconSearchNotFound from '../../Assets/icons/icon-searchNotFound.svg';
+/* eslint-disable */
+import Loader from './Loader';
 export default function Search() {
   const [searchText, setSearchText] = useState('');
   const [searchResults, setSearchResults] = useState(null);
@@ -17,22 +19,47 @@ export default function Search() {
   const debounceValue = useDebounce(searchText, 3000);
   const [, setError] = useState(null);
   const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
+    let cancel = false;
+
     async function fetchData(debounceValue) {
-      console.log(debounceValue);
+      setIsLoading(true);
+
       try {
         const result = await SearchAPI(token, debounceValue);
-        setSearchResults(result);
+        if (!cancel) {
+          // 취소되지 않았을 때에만 결과 업데이트
+          setSearchResults(result);
+          setIsLoading(false);
+        }
       } catch (error) {
-        setError(error);
-        console.error(error);
+        if (!cancel) {
+          setError(error);
+          setIsLoading(false);
+          console.error(error);
+        }
       }
     }
+
     if (searchText) {
       fetchData(debounceValue);
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 3000);
     }
-  }, [debounceValue]);
+
+    return () => {
+      cancel = true;
+      setSearchResults(null);
+    };
+  }, [debounceValue, searchText, token]);
+
+  useEffect(() => {
+    setSearchResults(null);
+  }, [searchText]);
+
   console.log(searchResults);
   const handleUser = (accountname) => {
     navigate(`/profile/${accountname}`);
@@ -41,7 +68,9 @@ export default function Search() {
     <Container>
       <UserSearch setSearchText={setSearchText}></UserSearch>
       <SearchListWrap>
-        {searchResults && searchResults.length > 0 ? (
+        {isLoading ? (
+          <Loader />
+        ) : searchResults && searchResults.length > 0 ? (
           searchResults.slice(0, 5).map((item, index) => {
             const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
 


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
검색한 내용을 지우면 렌더링 되었던 내용이 그대로 남아있었습니다.




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
cancel이라는 변수를 사용하여 비동기 작업이 중간에 취소되지 않도록 사용했습니다.
검색어가 변경될 떄 검색 결과를 setSearchResults(null) 로 초기화 했습니다.
빠르게 지웠을 때 계속 Loading이 되는 현상이 생겨 setTimeout을 사용해 로딩이 3초간 지속되면 검색 결과가 없다는 안내문구로 바뀌게 했습니다.
로딩이 되는 시간에 로딩 이미지를 추가하였습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->





https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/a9d96d82-65b2-48be-af12-bb5834faf06b







### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
로딩 이미지의 디자인이 괜찮은지 봐주시면 좋겠습니다.



### 특이 사항 :
Issue Number #217 

close: # 자기가 개발 전에 올린 이슈
