### PR TITLE
[ 🔧 Fix ] 게시글 및 검색화면 공식 마크 출력

### DIFF
--- a/moamoa/src/Components/Home/HomePostCardList.jsx
+++ b/moamoa/src/Components/Home/HomePostCardList.jsx
@@ -64,7 +64,7 @@ export default function HomePostCardList(post) {
             <Frofile>
               <PostCardUser
                 url={profileImgUrl}
-                username={postAuthorInfo.username.slice(3)}
+                username={postAuthorInfo.username}
                 accountname={postAuthorInfo.accountname}
                 loginAccountName={accountAtom}
               />

--- a/moamoa/src/Components/Home/HomePostCardList.jsx
+++ b/moamoa/src/Components/Home/HomePostCardList.jsx
@@ -71,7 +71,8 @@ export default function HomePostCardList(post) {
               <HomePostMoreBtn postid={postId}/>
             </Frofile>
             <Link to={postDetailUrl}>
-              <PostDesc>{postInfo.content}</PostDesc>
+              {postInfo.content!==""?<PostDesc>{postInfo.content}</PostDesc>:null}
+              
               {postImgUrl ? <PostImg src={postImgUrl} alt='게시글 사진' /> : null}
             </Link>
             <PostFooterContainer>
@@ -124,7 +125,7 @@ const Frofile = styled.div`
 const PostImg = styled.img`
   width: 35.8rem;
   height: 22.8rem;
-  margin: 0 auto;
+  margin: 1.2rem auto 0;
   aspect-ratio: 358/228;
   object-fit: cover;
   border-radius: 1rem;
@@ -134,7 +135,7 @@ const PostImg = styled.img`
 `;
 const PostDesc = styled.p`
   font-size: 1.4rem;
-  margin: 1.2rem 0;
+  margin: 1.2rem 0 0;
   line-height: 2rem;
   overflow:hidden;  
   display: -webkit-box;

--- a/moamoa/src/Components/Post/PostCardItem.jsx
+++ b/moamoa/src/Components/Post/PostCardItem.jsx
@@ -144,7 +144,7 @@ const PostImg = styled.img`
 `;
 const PostDesc = styled.p`
   font-size: 1.4rem;
-  margin: 1.2rem 0 1.6rem;
+  margin: 1.2rem 0;
   word-break: break-all;
   &:hover {
     cursor: default;

--- a/moamoa/src/Components/Post/PostCardItem.jsx
+++ b/moamoa/src/Components/Post/PostCardItem.jsx
@@ -68,7 +68,7 @@ export default function PostCardDetail({post}) {
           <PostArticle>
             <Frofile>
               <PostCardUser url={postAuthorInfo.image}
-                username={postAuthorInfo.username.slice(3)}
+                username={postAuthorInfo.username}
                 accountname={accountName} loginAccountName={accountAtom}
               />
               {accountAtom === accountName ? <MyPostMoreBtn

--- a/moamoa/src/Components/Post/PostCardList.jsx
+++ b/moamoa/src/Components/Post/PostCardList.jsx
@@ -76,7 +76,7 @@ export default function PostCardList(post) {
               />
             </Frofile>
             <Link to={postDetailUrl}>
-              <PostDesc>{post.post.content}</PostDesc>
+              {postItem.content !== "" ? <PostDesc>{postItem.content}</PostDesc> :null}
               {postImgUrl ? <PostImg src={postImgUrl} alt='게시글 사진' /> : null}
             </Link>
             <PostFooterContainer>
@@ -129,7 +129,7 @@ const Frofile = styled.div`
 const PostImg = styled.img`
   width: 35.8rem;
   height: 22.8rem;
-  margin: 0 auto;
+  margin: 1.2rem auto 0;
   aspect-ratio: 358/228;
   object-fit: cover;
   border-radius: 1rem;
@@ -139,7 +139,7 @@ const PostImg = styled.img`
 `;
 const PostDesc = styled.p`
   font-size: 1.4rem;
-  margin: 1.2rem 0;
+  margin: 1.2rem 0 0;
   line-height: 2rem;
   overflow:hidden;  
   display: -webkit-box;

--- a/moamoa/src/Components/Post/PostCardList.jsx
+++ b/moamoa/src/Components/Post/PostCardList.jsx
@@ -61,7 +61,7 @@ export default function PostCardList(post) {
             <Frofile>
               <PostCardUser
                 url={profileImgUrl}
-                username={postAuthorInfo.username.slice(3)}
+                username={postAuthorInfo.username}
                 accountname={postAuthorInfo.accountname}
                 loginAccountName={accountAtom}
               />

--- a/moamoa/src/Components/Post/PostCardUser.jsx
+++ b/moamoa/src/Components/Post/PostCardUser.jsx
@@ -23,10 +23,12 @@ export default function PostCardUser({url, username, accountname, loginAccountNa
             <UserInfo>
               <FrofileImg src={url} alt="사용자프로필"/>        
               <InfoText>
-                {username.slice(0,3) !== '[o]'?                
-                <UserName>{username.slice(3)}</UserName> :
-                <OrCont><UserName>{username.slice(3)}<UserCheck src={UserTypeCheck} alt=''/></UserName></OrCont>
-                }
+                <OrCont>
+                  <UserName>{username.slice(3)}</UserName>
+                  {username.slice(0,3) === '[o]'?                
+                  <UserCheck src={UserTypeCheck} alt=''/> : null
+                  }
+                </OrCont>
                 <AccountName>@{accountname}</AccountName>
               </InfoText>
             </UserInfo>
@@ -47,7 +49,7 @@ const FrofileImg = styled.img`
   width: 4.2rem;
   height: 4.2rem;
   border-radius: 100%;
-  margin-right: 1.2rem;
+  margin-right: 0.8rem;
 ` ;
 const UserInfo = styled.div`
   display: flex;

--- a/moamoa/src/Components/Post/PostCardUser.jsx
+++ b/moamoa/src/Components/Post/PostCardUser.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import UserTypeCheck from '../../Assets/icons/icon-usertype-check.svg';
 
 PostCardUser.propTypes = {
   url: PropTypes.string,
@@ -22,7 +23,10 @@ export default function PostCardUser({url, username, accountname, loginAccountNa
             <UserInfo>
               <FrofileImg src={url} alt="사용자프로필"/>        
               <InfoText>
-                <UserName>{username}</UserName>
+                {username.slice(0,3) !== '[o]'?                
+                <UserName>{username.slice(3)}</UserName> :
+                <OrCont><UserName>{username.slice(3)}<UserCheck src={UserTypeCheck} alt=''/></UserName></OrCont>
+                }
                 <AccountName>@{accountname}</AccountName>
               </InfoText>
             </UserInfo>
@@ -62,3 +66,14 @@ const AccountName = styled.p`
   line-height: 1.4rem;
   color: #767676;
 ` ;
+
+const OrCont = styled.div`
+  display: flex;
+  align-items: center;
+  vertical-align: top;
+`;
+
+const UserCheck = styled.img`
+  padding-left: 0.3rem;
+  width: 1.2rem
+`;

--- a/moamoa/src/Pages/Product/ProductDetail.jsx
+++ b/moamoa/src/Pages/Product/ProductDetail.jsx
@@ -21,7 +21,7 @@ export default function ProductDetail() {
 
   useEffect(() => {
     const getProductData = async () => {
-      const reqUrl = `https://api.mandarin.weniv.co.kr/product`;
+      const reqUrl = `https://api.mandarin.weniv.co.kr/product/?limit=400&skip=0`;
 
       try {
         const res = await fetch(reqUrl, {

--- a/moamoa/src/Pages/Search/Search.jsx
+++ b/moamoa/src/Pages/Search/Search.jsx
@@ -10,6 +10,7 @@ import useDebounce from '../../Hooks/Search/useDebounce';
 import { useNavigate } from 'react-router-dom';
 import SearchHighLight from '../../Components/Common/SearchHighLight';
 import iconSearchNotFound from '../../Assets/icons/icon-searchNotFound.svg';
+import UserTypeCheck from '../../Assets/icons/icon-usertype-check.svg';
 
 import Loader from './Loader';
 export default function Search() {
@@ -71,7 +72,7 @@ export default function Search() {
           <Loader />
         ) : searchResults && searchResults.length > 0 ? (
           searchResults.slice(0, 5).map((item, index) => {
-            const cleanedUserId = item.username.replace(/\[i\]|\[o\]/g, '');
+            const cleanedUserId = item.username.slice(3);
 
             return (
               <SearchWrap onClick={() => handleUser(item.accountname)} key={index}>
@@ -79,7 +80,10 @@ export default function Search() {
                   <SearchImg src={item.image} alt='' />
                 </SearchPhotoWrap>
                 <UserInfo>
-                  <UserId>{SearchHighLight(cleanedUserId, searchText)}</UserId>
+                  <OrCont>
+                    <UserId>{SearchHighLight(cleanedUserId, searchText)}</UserId>
+                    {item.username.slice(0,3)==="[o]" ? <UserCheck src={UserTypeCheck} alt=''/> : null}
+                </OrCont>
                   <UserText>{item.intro}</UserText>
                 </UserInfo>
               </SearchWrap>
@@ -165,4 +169,14 @@ const NotFoundWrap = styled.div`
     transform: translateX(5%);
     color: #919191;
   }
+`;
+
+const OrCont = styled.div`
+  display: flex;
+  align-items: center;
+  vertical-align: top;
+`;
+const UserCheck = styled.img`
+  padding-left: 0.3rem;
+  width: 1.2rem
 `;


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
게시글 유저의 프로필 및 검색화면에서 기관 사용자의 공식 마크가 나오도록 수정했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/e7ca1dfd-68e8-4df2-b4f6-09ca13bca043)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number

close: #231 