### PR TITLE
[✨ Feature] 테스트 계정으로 로그인 기능 추가

### DIFF
--- a/moamoa/src/Hooks/Auth/useLogin.jsx
+++ b/moamoa/src/Hooks/Auth/useLogin.jsx
@@ -13,11 +13,12 @@ const useLogin = () => {
 
   const [userData, setUserData] = useState({
     user: {
-      email: 'moa_festa@moamoa.com',
-      password: '13231323',
+      email: '',
+      password: '',
     },
   });
   const [loginFailMessage, setLoginFailMessage] = useState('');
+  const [isTestAccount, setIsTestAccount] = useState(false);
 
   const setUserToken = useSetRecoilState(userTokenAtom);
   const setIsLoginState = useSetRecoilState(isLoginAtom);
@@ -34,6 +35,24 @@ const useLogin = () => {
   const updateUserData = (e) => {
     updateInputState(e, setUserData, 'user');
   };
+
+  const loginWithTestAccount = () => {
+    setIsTestAccount(!isTestAccount);
+    console.log(isTestAccount);
+
+    setUserData((prevState) => ({
+      ...prevState,
+      user: {
+        ...prevState.user,
+        email: 'moa_festa@moamoa.com',
+        password: '13231323',
+      },
+    }));
+  };
+
+  useEffect(() => {
+    isTestAccount && performLogin();
+  }, [isTestAccount]);
 
   const performLogin = async () => {
     const [res, error] = await login(userData);
@@ -63,6 +82,8 @@ const useLogin = () => {
     updateUserData,
     submitLoginForm,
     loginFailMessage,
+    loginWithTestAccount,
+    isTestAccount,
   };
 };
 

--- a/moamoa/src/Pages/Auth/Login.jsx
+++ b/moamoa/src/Pages/Auth/Login.jsx
@@ -11,7 +11,14 @@ import {
 } from '../../Components/Common/FormLoginAndJoin';
 
 const Login = () => {
-  const { userData, updateUserData, submitLoginForm, loginFailMessage } = useLogin();
+  const {
+    userData,
+    updateUserData,
+    submitLoginForm,
+    loginFailMessage,
+    loginWithTestAccount,
+    // isTestAccount,
+  } = useLogin();
 
   return (
     <LoginAndJoinContainer>
@@ -32,17 +39,58 @@ const Login = () => {
           value={userData.user.password}
         />
         <StyledErrorMsg>{loginFailMessage}</StyledErrorMsg>
-        <LoginBtn type='submit'>로그인</LoginBtn>
+        <LoginBtn type='submit'>로그인하기</LoginBtn>
+        <CheckBoxContainer onClick={loginWithTestAccount}>
+          <CheckBox
+            type='checkbox'
+            id='testAccount'
+            name='testAccount'
+            onClick={loginWithTestAccount}
+          />
+          <label htmlFor='testAccount'>체험하기</label>
+        </CheckBoxContainer>
         <LinkContainer>
-          <Link to='/user/signUp'>이메일로 회원가입</Link>
+          <Link to='/user/signUp'>이메일로 회원가입하기</Link>
         </LinkContainer>
       </Form>
     </LoginAndJoinContainer>
   );
 };
 
+const CheckBoxContainer = styled.div`
+  margin: 9px 0 21px 0;
+  background-color: #cccccc;
+  border-radius: 44px;
+  font-weight: 700;
+  padding: 11px;
+  color: white;
+  letter-spacing: -1px;
+  cursor: pointer;
+
+  label,
+  input {
+    cursor: pointer;
+  }
+
+  &:hover {
+    background-color: #87b7e4;
+  }
+`;
+
+const CheckBox = styled.input`
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+`;
+
 const LoginBtn = styled(CommonBtn)`
-  margin: 26px 0 21px 0;
+  margin-top: 21px;
+  background-color: #cccccc;
+
+  &:hover {
+    background-color: #87b7e4;
+  }
 `;
 
 const LinkContainer = styled.div`


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 모아모아를 처음 방문한 사용자가 회원 가입 없이 사이트를 체험할 수 있도록 기능을 추가했습니다. 




### 작업 내역

+ 체험하기 클릭 시 자동 로그인 되어 홈으로 이동합니다.
+ 테스트 계정은 moa_festa 계정을 사용했습니다.
+ 기존의 사이트 사용자가 로그인할 때 이동 동선을 고려하여 비밀번호 입력 창 바로 아래에 로그인하기 그 다음에 체험하기를 두었습니다.



### 작업 후 기대 동작(스크린샷) 
<img src='https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/5083cc45-c0fa-4f33-a3b0-8e92effc96ba' width=50%>




### PR 특이 사항
+ 기능 추가하면서 체험하기 버튼에 로그인 버튼과 동일한 스타일을 적용했는데 혹시 다른 좋은 아이디어 있으시다면 말씀 부탁 드리겠습니다:) 




### 특이 사항 :
Issue Number

close: # 279
