### PR TITLE
[✨ Feature] 행사 등록(상품 등록) 시 행사 장소 추가

### DIFF
--- a/moamoa/src/Components/Common/ProductSharedStyle.jsx
+++ b/moamoa/src/Components/Common/ProductSharedStyle.jsx
@@ -90,7 +90,7 @@ export const SelectedButton = styled.button`
   }
 `;
 
-export const EventNameInput = styled.input`
+export const TextInput = styled.input`
   border: none;
   outline: none;
   border-bottom: 1.5px solid #dbdbdb;

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -16,7 +16,7 @@ import {
   Image,
   LayoutContainer,
   SelectedButton,
-  EventNameInput,
+  TextInput,
   PeriodInputContainer,
   PeriodInput,
   Textarea,
@@ -38,6 +38,7 @@ const ProductAdd = () => {
   const [endDate, setEndDate] = useState('');
   const { progressPeriod, dateSelectionErrorMsg } = useProgressPeriodEffect(startDate, endDate);
   const [description, setDescription] = useState('');
+  const [location, setLocation] = useState('');
 
   const handleChangeImage = async (e) => {
     handleUploadImage(e, setImgSrc, 'product.url');
@@ -49,7 +50,7 @@ const ProductAdd = () => {
       product: {
         itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
         price: progressPeriod,
-        link: description,
+        link: `${description}+${location}`,
         itemImage: imgSrc.product.url,
       },
     };
@@ -112,7 +113,7 @@ const ProductAdd = () => {
           </LayoutContainer>
           <LayoutContainer>
             <label htmlFor='event-name'>행사명</label>
-            <EventNameInput
+            <TextInput
               id='event-name'
               type='text'
               placeholder='2~22자 이내여야 합니다.'
@@ -120,7 +121,7 @@ const ProductAdd = () => {
               value={productName}
               minLength={2}
               maxLength={22}
-            ></EventNameInput>
+            ></TextInput>
           </LayoutContainer>
           <LayoutContainer>
             <label htmlFor='event-period'>행사 기간</label>
@@ -143,6 +144,17 @@ const ProductAdd = () => {
               ></PeriodInput>
             </PeriodInputContainer>
             <StyledErrorMsg>{dateSelectionErrorMsg}</StyledErrorMsg>
+          </LayoutContainer>
+          <LayoutContainer>
+            <label htmlFor='eventLocation'>행사 장소</label>
+            <TextInput
+              type='text'
+              id='eventLocation'
+              value={location}
+              onChange={(e) => {
+                setLocation(e.target.value);
+              }}
+            />
           </LayoutContainer>
           <LayoutContainer>
             <label htmlFor='event-detail'>상세 설명</label>

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -18,7 +18,7 @@ import {
   Image,
   LayoutContainer,
   SelectedButton,
-  EventNameInput,
+  TextInput,
   PeriodInputContainer,
   PeriodInput,
   Textarea,
@@ -152,7 +152,7 @@ const ProductEdit = () => {
         </LayoutContainer>
         <LayoutContainer>
           <label htmlFor='event-name'>행사명</label>
-          <EventNameInput
+          <TextInput
             id='event-name'
             type='text'
             placeholder='2~22자 이내여야 합니다.'
@@ -161,7 +161,7 @@ const ProductEdit = () => {
             value={productInputs.product.itemName}
             minLength={2}
             maxLength={22}
-          ></EventNameInput>
+          ></TextInput>
         </LayoutContainer>
         <LayoutContainer>
           <label htmlFor='event-period'>행사 기간 </label>


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
행사 상세 페이지의 카카오 지도에서 보다 정확한 위치 표시를 위해 행사 등록 시 행사 장소를 추가할 수 있도록 설정합니다.




### 작업 내역
1. 행사 장소 label과 input을 생성합니다.
    
    ![상품 등록 3](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/1957c7f5-1901-4f51-a3a9-7342a58981b3)
    



2. useState를 사용하여 상태 location을 추가합니다.
    
    ![상품등록 1](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/f5416e31-3acc-4648-824c-a3aa45f0f74c)
    
3. 행사 등록(상품 등록) 시 product 객체의 link 속성 값에 ‘상세설명+행사장소' 형태로 서버에 데이터를 보냅니다.
    
    ![상품등록 2](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/cc1d741e-77f0-4c3d-afed-54701f240566)



### 작업 후 기대 동작(스크린샷) 
Req |Res
--- | --- | 
![상품 등록](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/996209a9-84be-4431-9b12-d8fd20e1ebcb) |![상품 등록 API RES](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/1aa15b12-e653-4443-8251-f7141b1fdd71)|




### PR 특이 사항
행사 수정 페이지의 행사 장소는 상세 페이지 작업 끝나시면 추가하겠습니당:)
다음 작업은 이미지 최적화 또는 상품 등록 코드 리팩토링하겠습니다!




### 특이 사항 :
Issue Number

close: # 296
