### PR TITLE
[♻️ Refactor /✨ Feature] 상품 등록 및 수정 코드 리팩토링, 상품 수정 페이지 행사 장소 추가

### DIFF
--- a/moamoa/src/Hooks/Product/useDateValidation.jsx
+++ b/moamoa/src/Hooks/Product/useDateValidation.jsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 
-const useProgressPeriodEffect = (startDate, endDate) => {
-  const [progressPeriod, setProgressPeriod] = useState(1);
+const removeHyphen = (date) => {
+  return date ? date.replaceAll('-', '') : '';
+};
+
+const useDateValidation = (startDate, endDate) => {
   const [dateSelectionErrorMsg, setDateSelectionErrorMsg] = useState('');
 
   useEffect(() => {
@@ -11,19 +14,12 @@ const useProgressPeriodEffect = (startDate, endDate) => {
     } else {
       setDateSelectionErrorMsg('');
     }
-
-    const selectedDates = [];
-    if (startDate) {
-      selectedDates.push(startDate.replaceAll('-', ''));
-    }
-    if (endDate) {
-      selectedDates.push(endDate.replaceAll('-', ''));
-    }
-    const combineDates = parseInt(selectedDates.join(''));
-    setProgressPeriod(combineDates);
   }, [startDate, endDate]);
+
+  const selectedDates = [removeHyphen(startDate), removeHyphen(endDate)];
+  const progressPeriod = parseInt(selectedDates.join(''));
 
   return { progressPeriod, dateSelectionErrorMsg };
 };
 
-export default useProgressPeriodEffect;
+export default useDateValidation;

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { handleUploadImage } from '../../Utils/handleUploadImage';
 import { uploadProduct } from '../../API/Product/ProductAPI';
-import useProgressPeriodEffect from '../../Hooks/Product/useProgressPeriodEffect';
+import useDateValidation from '../../Hooks/Product/useDateValidation';
 // Styled-Component 수정 예정
 import { Container } from '../../Components/Common/Container';
 import Gobackbtn from '../../Components/Common/GoBackbtn';
@@ -10,7 +10,6 @@ import DefaultImg from '../../Assets/images/img-product-default.png';
 import {
   Form,
   Header,
-  HeaderButton,
   ImgLayoutContainer,
   ImageLabel,
   Image,
@@ -36,9 +35,11 @@ const ProductAdd = () => {
   const [productName, setProductName] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const { progressPeriod, dateSelectionErrorMsg } = useProgressPeriodEffect(startDate, endDate);
-  const [description, setDescription] = useState('');
   const [location, setLocation] = useState('');
+  const [description, setDescription] = useState('');
+  const [missingInputMessage, setMissingInputMessage] = useState('');
+
+  const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
 
   const handleChangeImage = async (e) => {
     handleUploadImage(e, setImgSrc, 'product.url');
@@ -46,6 +47,7 @@ const ProductAdd = () => {
 
   const submitProduct = async (e) => {
     e.preventDefault();
+
     const productData = {
       product: {
         itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
@@ -54,30 +56,34 @@ const ProductAdd = () => {
         itemImage: imgSrc.product.url,
       },
     };
-    await uploadProduct(productData);
-    navigate('/product/list');
-  };
 
-  const isDisabled =
-    !imgSrc.product.url ||
-    productName.length < 2 ||
-    !startDate ||
-    !endDate ||
-    !description ||
-    !productType ||
-    startDate > endDate;
+    if (
+      !imgSrc.product.url ||
+      productName.length < 2 ||
+      !startDate ||
+      !endDate ||
+      !location ||
+      !description ||
+      !productType ||
+      startDate > endDate
+    ) {
+      setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
+    } else {
+      setMissingInputMessage('');
+      await uploadProduct(productData);
+      navigate('/product/list');
+    }
+  };
 
   return (
     <>
       <Container>
         <Header>
           <Gobackbtn />
-          <HeaderButton onClick={submitProduct} disabled={isDisabled}>
-            저장
-          </HeaderButton>
+          {/* <HeaderButton onClick={submitProduct}>저장</HeaderButton> */}
         </Header>
         <h1 className='a11y-hidden'>상품 등록 페이지</h1>
-        <Form>
+        <Form onSubmit={submitProduct}>
           <ImgLayoutContainer>
             <h2>이미지 등록</h2>
             <ImageLabel htmlFor='upload-file'>
@@ -165,6 +171,8 @@ const ProductAdd = () => {
               value={description}
             ></Textarea>
           </LayoutContainer>
+          <p> {missingInputMessage}</p>
+          <button type='submit'>저장</button>
         </Form>
       </Container>
     </>

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { handleUploadImage } from '../../Utils/handleUploadImage';
 import { getProductDetail, editProduct } from '../../API/Product/ProductAPI';
+import useDateValidation from '../../Hooks/Product/useDateValidation';
 import _ from 'lodash';
-import useProgressPeriodEffect from '../../Hooks/Product/useProgressPeriodEffect';
-import { updateInputState } from '../../Utils/updateInputState';
+
 // Styled-Component 수정 예정
 import { Container } from '../../Components/Common/Container';
 import Gobackbtn from '../../Components/Common/GoBackbtn';
@@ -12,7 +12,6 @@ import DefaultImg from '../../Assets/images/img-product-default.png';
 import {
   Form,
   Header,
-  HeaderButton,
   ImgLayoutContainer,
   ImageLabel,
   Image,
@@ -30,34 +29,33 @@ const ProductEdit = () => {
   const params = useParams();
   const productId = params.product_id;
 
-  const [productInputs, setProductInputs] = useState({
+  const [imgSrc, setImgSrc] = useState({
     product: {
-      itemName: '',
-      price: '',
-      link: '',
-      itemImage: '',
+      url: DefaultImg,
+      alt: '',
     },
   });
   const [productType, setProductType] = useState('');
+  const [productName, setProductName] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-  const { progressPeriod, dateSelectionErrorMsg } = useProgressPeriodEffect(startDate, endDate);
+  const [location, setLocation] = useState('');
+  const [description, setDescription] = useState('');
+  const [missingInputMessage, setMissingInputMessage] = useState('');
 
-  const handleProductName = (product) => {
-    product.includes('[f]') ? setProductType('festival') : setProductType('experience');
-    return product.slice(3);
-  };
+  const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
 
+  //수정
   const getProductData = (data) => {
-    setProductInputs((prev) => ({
-      product: {
-        ...prev.productInput,
-        itemName: handleProductName(data.product.itemName),
-        price: data.product.price,
-        link: data.product.link,
-        itemImage: data.product.itemImage,
-      },
-    }));
+    setProductType(data.product.itemName.includes('[f]') ? 'festival' : 'experience');
+    setProductName(data.product.itemName.slice(3));
+
+    const productImg = _.set({ ...imgSrc }, 'product.url', data.product.itemImage);
+    setImgSrc(productImg);
+
+    const [description, location] = data.product.link.split('+');
+    setDescription(description);
+    setLocation(location);
 
     const period = data.product.price.toString();
     setStartDate(`${period.slice(0, 4)}-${period.slice(4, 6)}-${period.slice(6, 8)}`);
@@ -71,56 +69,54 @@ const ProductEdit = () => {
 
     fetchProductInfo();
   }, []);
+  //
 
   const handleChangeImage = async (e) => {
-    handleUploadImage(e, setProductInputs, 'product.itemImage');
+    handleUploadImage(e, setImgSrc, 'product.url');
   };
 
-  const updateProductInputs = (e) => {
-    updateInputState(e, setProductInputs, 'product');
-  };
-
-  const submitModifiedProduct = async (e) => {
+  const submitProductForm = async (e) => {
     e.preventDefault();
 
-    const prefix = productType === 'festival' ? '[f]' : '[e]';
-    const productData = _.set(
-      { ...productInputs },
-      'product.itemName',
-      prefix + productInputs.product.itemName,
-    );
-    productData.product.price = progressPeriod;
+    const productData = {
+      product: {
+        itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
+        price: progressPeriod,
+        link: `${description}+${location}`,
+        itemImage: imgSrc.product.url,
+      },
+    };
 
-    await editProduct(productId, productData);
-    navigate('/product/list');
+    if (
+      !imgSrc.product.url ||
+      productName.length < 2 ||
+      !startDate ||
+      !endDate ||
+      !location ||
+      !description ||
+      !productType ||
+      startDate > endDate
+    ) {
+      setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
+    } else {
+      setMissingInputMessage('');
+      await editProduct(productId, productData);
+      navigate('/product/list');
+    }
   };
-
-  const isDisabled =
-    !productInputs.product.itemImage ||
-    productInputs.product.itemName.length < 2 ||
-    !startDate ||
-    !endDate ||
-    !productInputs.product.link ||
-    !productType ||
-    startDate > endDate;
 
   return (
     <Container>
       <Header>
         <Gobackbtn />
-        <HeaderButton onClick={submitModifiedProduct} disabled={isDisabled}>
-          수정
-        </HeaderButton>
+        {/* <HeaderButton onClick={submitProductForm}>수정</HeaderButton> */}
       </Header>
       <h1 className='a11y-hidden'>상품 수정 페이지</h1>
-      <Form>
+      <Form onSubmit={submitProductForm}>
         <ImgLayoutContainer>
           <h2>이미지 등록</h2>
           <ImageLabel htmlFor='upload-file'>
-            <Image
-              src={productInputs.product.itemImage || DefaultImg}
-              alt={productInputs.product.itemName}
-            />
+            <Image src={imgSrc.product.url || DefaultImg} alt={imgSrc.product.alt} />
           </ImageLabel>
           <input
             className='a11y-hidden'
@@ -156,9 +152,9 @@ const ProductEdit = () => {
             id='event-name'
             type='text'
             placeholder='2~22자 이내여야 합니다.'
-            onChange={updateProductInputs}
+            onChange={(e) => setProductName(e.target.value)}
             name='itemName'
-            value={productInputs.product.itemName}
+            value={productName}
             minLength={2}
             maxLength={22}
           ></TextInput>
@@ -186,15 +182,28 @@ const ProductEdit = () => {
           <StyledErrorMsg>{dateSelectionErrorMsg}</StyledErrorMsg>
         </LayoutContainer>
         <LayoutContainer>
+          <label htmlFor='eventLocation'>행사 장소</label>
+          <TextInput
+            type='text'
+            id='eventLocation'
+            value={location}
+            onChange={(e) => {
+              setLocation(e.target.value);
+            }}
+          />
+        </LayoutContainer>
+        <LayoutContainer>
           <label htmlFor='event-detail'>상세 설명</label>
           <Textarea
             id='event-detail'
             name='link'
             placeholder='행사 관련 정보를 자유롭게 기재해주세요.'
-            onChange={updateProductInputs}
-            value={productInputs.product.link}
+            onChange={(e) => setDescription(e.target.value)}
+            value={description}
           ></Textarea>
         </LayoutContainer>
+        <p> {missingInputMessage}</p>
+        <button type='submit'>수정</button>
       </Form>
     </Container>
   );


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
불필요한 상태 변수를 줄이고 중복된 함수는 추출했습니다.
상품 등록 또는 수정 폼 제출 시 누락된 입력사항이 있다면 메세지가 출력되도록 합니다.
상품 수정 폼에서 행사 장소를 추가합니다.
상품 등록 또는 상품 수정 폼에서 제출 버튼(등록, 수정) 위치를 바꾸었습니다. 스타일 상으로는 헤더에 위치해있는 것이 맞지만 html 문서 구조를 생각했을 때 폼 안에 제출 버튼이 위치해야 한다고 생각했습니다. 스타일은 추후 수정하겠습니다! 

### 작업 내역
+ useDateValidation.jsx
   + startDate와 endDate에서 '-'를 제거하는 로직이 중복으로 사용되고 있어 함수로 추출했습니다.

   + 상태변수 progressPeriod는 업데이트하기 위해 특별한 작업을 수행할 필요가 없습니다. 따라서 불필요한 렌더링을 줄이기 위해 일반 변수로 변경했습니다.
상태 변수 startDate, endDate로 progressPeriod(진행기간)를 계산합니다.

   + 기능과 목적을 명확히 하도록 훅 이름 변경합니다. 
시작 날짜와 종료 날짜를 받아서 특정 형식으로 변환하고, 이 두 날짜의 유효성을 검사하므로 useProgressPeriodEffect => useDateValidation 변경


+ ProductAdd.jsx, ProductEdit.jsx
   + Feat: 사용자가 상품 등록 시 필수 입력사항을 누락했다면 메세지를 출력합니다. 
   + 필수 입력사항 누락 메세지 스타일은 스타일 수정 작업 때 진행하겠습니다!


+ ProductEdit.jsx
    + Feat: 상품(행사) 수정 페이지에 행사 장소 추가했습니다. (스크린 샷 첨부)
   + 서버에 '${description}+${location}' 형태로 product link 값에 저장되어 있는 상황 아래와 같이 작업했습니다. 
       <img src='https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/f0e79273-bc70-4ba2-9bd4-3bcd8bf4f2ce' width='70%'>




### 작업 후 기대 동작(스크린샷) 
<img src='https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/2ded2464-969b-4214-8661-a82ce05072da' width='50%'>








### PR 특이 사항





### 특이 사항 :
Issue Number

close: # 299
