### PR TITLE
[♻️ Refactor] 상품 등록과 상품 수정 컴포넌트 간에 중복 로직 분리

### DIFF
--- a/moamoa/src/Components/Product/ProductForm.jsx
+++ b/moamoa/src/Components/Product/ProductForm.jsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { handleUploadImage } from '../../Utils/handleUploadImage.jsx';
+
+import {
+  Form,
+  ImgLayoutContainer,
+  ImageLabel,
+  Image,
+  LayoutContainer,
+  SelectedButton,
+  TextInput,
+  PeriodInputContainer,
+  PeriodInput,
+  Textarea,
+  StyledErrorMsg,
+} from '../../Components/Common/ProductSharedStyle';
+
+export function ProductForm({
+  product,
+  setImgSrc,
+  setProductType,
+  setProductName,
+  setStartDate,
+  setEndDate,
+  dateSelectionErrorMsg,
+  setLocation,
+  setDescription,
+  onSubmit,
+  missingInputMessage,
+}) {
+  const handleChangeImage = async (e) => {
+    const imageFile = e.target.files[0];
+    if (!imageFile) {
+      return;
+    }
+    const imageInfo = await handleUploadImage(imageFile);
+    setImgSrc(imageInfo.imageUrl);
+  };
+
+  return (
+    <Form onSubmit={onSubmit}>
+      <ImgLayoutContainer>
+        <h2>이미지 등록</h2>
+        <ImageLabel htmlFor='upload-file'>
+          <Image src={product.imgSrc} alt={product.productName} />
+        </ImageLabel>
+        <input
+          className='a11y-hidden'
+          id='upload-file'
+          type='file'
+          accept='image/*'
+          onChange={handleChangeImage}
+        ></input>
+        <p>* 행사 관련 이미지를 등록해주세요.</p>
+      </ImgLayoutContainer>
+      <LayoutContainer>
+        <h2>카테고리</h2>
+        <div>
+          <SelectedButton
+            type='button'
+            onClick={() => setProductType('festival')}
+            selected={product.productType === 'festival'}
+          >
+            축제
+          </SelectedButton>
+          <SelectedButton
+            type='button'
+            onClick={() => setProductType('experience')}
+            selected={product.productType === 'experience'}
+          >
+            체험
+          </SelectedButton>
+        </div>
+      </LayoutContainer>
+      <LayoutContainer>
+        <label htmlFor='event-name'>행사명</label>
+        <TextInput
+          id='event-name'
+          type='text'
+          placeholder='2~22자 이내여야 합니다.'
+          onChange={(e) => setProductName(e.target.value)}
+          value={product.productName}
+          minLength={2}
+          maxLength={22}
+        ></TextInput>
+      </LayoutContainer>
+      <LayoutContainer>
+        <label htmlFor='event-period'>행사 기간</label>
+        <PeriodInputContainer>
+          <PeriodInput
+            type='date'
+            id='event-period'
+            onChange={(e) => setStartDate(e.target.value)}
+            value={product.startDate}
+            pattern='yyyy-MM-dd'
+            max='9999-12-31'
+          ></PeriodInput>
+          <PeriodInput
+            type='date'
+            id='event-period'
+            onChange={(e) => setEndDate(e.target.value)}
+            value={product.endDate}
+            pattern='yyyy-MM-dd'
+            max='9999-12-31'
+          ></PeriodInput>
+        </PeriodInputContainer>
+        <StyledErrorMsg>{dateSelectionErrorMsg}</StyledErrorMsg>
+      </LayoutContainer>
+      <LayoutContainer>
+        <label htmlFor='eventLocation'>행사 장소</label>
+        <TextInput
+          type='text'
+          id='eventLocation'
+          value={product.location}
+          onChange={(e) => {
+            setLocation(e.target.value);
+          }}
+        />
+      </LayoutContainer>
+      <LayoutContainer>
+        <label htmlFor='event-detail'>상세 설명</label>
+        <Textarea
+          id='event-detail'
+          placeholder='행사 관련 정보를 자유롭게 기재해주세요.'
+          onChange={(e) => setDescription(e.target.value)}
+          value={product.description}
+        ></Textarea>
+      </LayoutContainer>
+      <p> {missingInputMessage}</p>
+      <button type='submit'>저장</button>
+    </Form>
+  );
+}
+
+ProductForm.propTypes = {
+  product: PropTypes.object.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  setImgSrc: PropTypes.func.isRequired,
+  setProductType: PropTypes.func.isRequired,
+  setProductName: PropTypes.func.isRequired,
+  setStartDate: PropTypes.func.isRequired,
+  setEndDate: PropTypes.func.isRequired,
+  dateSelectionErrorMsg: PropTypes.string,
+  setLocation: PropTypes.func.isRequired,
+  setDescription: PropTypes.func.isRequired,
+  missingInputMessage: PropTypes.string,
+};

--- a/moamoa/src/Hooks/Auth/useSignUp.jsx
+++ b/moamoa/src/Hooks/Auth/useSignUp.jsx
@@ -29,13 +29,30 @@ const useSignUp = () => {
   const [imgSrc, setImgSrc] = useState({
     profile: {
       url: DefaultProfileImage,
-      alt: '',
+      alt: '모아모아 기본 프로필 이미지',
     },
   });
 
   const handleChangeImage = async (e) => {
-    handleUploadImage(e, setUserData, 'user.image');
-    handleUploadImage(e, setImgSrc, 'profile.url');
+    const imageFile = e.target.files[0];
+    if (!imageFile) {
+      return;
+    }
+
+    const { imageUrl, imageAlt } = await handleUploadImage(imageFile);
+
+    setUserData((prevState) => {
+      const newState = _.cloneDeep(prevState);
+      _.set(newState, 'user.image', imageUrl);
+      return newState;
+    });
+
+    setImgSrc((prevState) => {
+      const newState = _.cloneDeep(prevState);
+      _.set(newState, 'profile.url', imageUrl);
+      _.set(newState, 'profile.alt', imageAlt);
+      return newState;
+    });
   };
 
   const { errorMessages } = InputErrorMessagesReducer();

--- a/moamoa/src/Hooks/Product/useProductData.jsx
+++ b/moamoa/src/Hooks/Product/useProductData.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export const useProductData = (initialState) => {
+  const [imgSrc, setImgSrc] = useState(initialState.imgSrc);
+  const [productType, setProductType] = useState(initialState.productType);
+  const [productName, setProductName] = useState(initialState.productName);
+  const [startDate, setStartDate] = useState(initialState.startDate);
+  const [endDate, setEndDate] = useState(initialState.endDate);
+  const [location, setLocation] = useState(initialState.location);
+  const [description, setDescription] = useState(initialState.description);
+  const [missingInputMessage, setMissingInputMessage] = useState(initialState.missingInputMessage);
+
+  return {
+    imgSrc,
+    setImgSrc,
+    productType,
+    setProductType,
+    productName,
+    setProductName,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    location,
+    setLocation,
+    description,
+    setDescription,
+    missingInputMessage,
+    setMissingInputMessage,
+  };
+};

--- a/moamoa/src/Hooks/Product/useSubmitProductForm.jsx
+++ b/moamoa/src/Hooks/Product/useSubmitProductForm.jsx
@@ -1,0 +1,30 @@
+export const useSubmitProductForm = (
+  uploadProduct,
+  navigate,
+  productData,
+  validationChecks,
+  productId = null,
+) => {
+  const submitProductForm = async (e) => {
+    e.preventDefault();
+
+    if (!validationChecks()) {
+      return;
+    }
+
+    const processProduct = async () => {
+      if (productId) {
+        // 상품 수정
+        await uploadProduct(productId, productData);
+      } else {
+        // 상품 등록
+        await uploadProduct(productData);
+      }
+    };
+
+    await processProduct();
+    navigate('/product/list');
+  };
+
+  return submitProductForm;
+};

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -1,64 +1,63 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { handleUploadImage } from '../../Utils/handleUploadImage';
+import { ProductForm } from '../../Components/Product/ProductForm';
+import { useProductData } from '../../Hooks/Product/useProductData';
+import { useSubmitProductForm } from '../../Hooks/Product/useSubmitProductForm';
 import { uploadProduct } from '../../API/Product/ProductAPI';
 import useDateValidation from '../../Hooks/Product/useDateValidation';
 // Styled-Component 수정 예정
 import { Container } from '../../Components/Common/Container';
 import Gobackbtn from '../../Components/Common/GoBackbtn';
 import DefaultImg from '../../Assets/images/img-product-default.png';
-import {
-  Form,
-  Header,
-  ImgLayoutContainer,
-  ImageLabel,
-  Image,
-  LayoutContainer,
-  SelectedButton,
-  TextInput,
-  PeriodInputContainer,
-  PeriodInput,
-  Textarea,
-  StyledErrorMsg,
-} from '../../Components/Common/ProductSharedStyle';
+import { Header } from '../../Components/Common/ProductSharedStyle';
 
 const ProductAdd = () => {
   const navigate = useNavigate();
 
-  const [imgSrc, setImgSrc] = useState({
-    product: {
-      url: DefaultImg,
-      alt: '',
-    },
-  });
-  const [productType, setProductType] = useState('');
-  const [productName, setProductName] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [location, setLocation] = useState('');
-  const [description, setDescription] = useState('');
-  const [missingInputMessage, setMissingInputMessage] = useState('');
+  const initialState = {
+    imgSrc: DefaultImg,
+    productType: '',
+    productName: '',
+    startDate: '',
+    endDate: '',
+    location: '',
+    description: '',
+    missingInputMessage: '',
+  };
+
+  const {
+    imgSrc,
+    setImgSrc,
+    productType,
+    setProductType,
+    productName,
+    setProductName,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    location,
+    setLocation,
+    description,
+    setDescription,
+    missingInputMessage,
+    setMissingInputMessage,
+  } = useProductData(initialState);
 
   const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
 
-  const handleChangeImage = async (e) => {
-    handleUploadImage(e, setImgSrc, 'product.url');
+  const productData = {
+    product: {
+      itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
+      price: progressPeriod,
+      link: `${description}+[l]${location}`,
+      itemImage: imgSrc,
+    },
   };
 
-  const submitProduct = async (e) => {
-    e.preventDefault();
-
-    const productData = {
-      product: {
-        itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
-        price: progressPeriod,
-        link: `${description}+${location}`,
-        itemImage: imgSrc.product.url,
-      },
-    };
-
+  const validationChecks = () => {
     if (
-      !imgSrc.product.url ||
+      !imgSrc ||
       productName.length < 2 ||
       !startDate ||
       !endDate ||
@@ -68,112 +67,40 @@ const ProductAdd = () => {
       startDate > endDate
     ) {
       setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
+      return false;
     } else {
       setMissingInputMessage('');
-      await uploadProduct(productData);
-      navigate('/product/list');
+      return true;
     }
   };
+
+  const submitProductForm = useSubmitProductForm(
+    uploadProduct,
+    navigate,
+    productData,
+    validationChecks,
+  );
 
   return (
     <>
       <Container>
         <Header>
           <Gobackbtn />
-          {/* <HeaderButton onClick={submitProduct}>저장</HeaderButton> */}
         </Header>
         <h1 className='a11y-hidden'>상품 등록 페이지</h1>
-        <Form onSubmit={submitProduct}>
-          <ImgLayoutContainer>
-            <h2>이미지 등록</h2>
-            <ImageLabel htmlFor='upload-file'>
-              <Image src={imgSrc.product.url || DefaultImg} alt={imgSrc.product.alt} />
-            </ImageLabel>
-            <input
-              className='a11y-hidden'
-              id='upload-file'
-              type='file'
-              accept='image/*'
-              onChange={handleChangeImage}
-            ></input>
-            <p>* 행사 관련 이미지를 등록해주세요.</p>
-          </ImgLayoutContainer>
-          <LayoutContainer>
-            <h2>카테고리</h2>
-            <div>
-              <SelectedButton
-                type='button'
-                onClick={() => setProductType('festival')}
-                selected={productType === 'festival'}
-              >
-                축제
-              </SelectedButton>
-              <SelectedButton
-                type='button'
-                onClick={() => setProductType('experience')}
-                selected={productType === 'experience'}
-              >
-                체험
-              </SelectedButton>
-            </div>
-          </LayoutContainer>
-          <LayoutContainer>
-            <label htmlFor='event-name'>행사명</label>
-            <TextInput
-              id='event-name'
-              type='text'
-              placeholder='2~22자 이내여야 합니다.'
-              onChange={(e) => setProductName(e.target.value)}
-              value={productName}
-              minLength={2}
-              maxLength={22}
-            ></TextInput>
-          </LayoutContainer>
-          <LayoutContainer>
-            <label htmlFor='event-period'>행사 기간</label>
-            <PeriodInputContainer>
-              <PeriodInput
-                type='date'
-                id='event-period'
-                onChange={(e) => setStartDate(e.target.value)}
-                value={startDate}
-                pattern='yyyy-MM-dd'
-                max='9999-12-31'
-              ></PeriodInput>
-              <PeriodInput
-                type='date'
-                id='event-period'
-                onChange={(e) => setEndDate(e.target.value)}
-                value={endDate}
-                pattern='yyyy-MM-dd'
-                max='9999-12-31'
-              ></PeriodInput>
-            </PeriodInputContainer>
-            <StyledErrorMsg>{dateSelectionErrorMsg}</StyledErrorMsg>
-          </LayoutContainer>
-          <LayoutContainer>
-            <label htmlFor='eventLocation'>행사 장소</label>
-            <TextInput
-              type='text'
-              id='eventLocation'
-              value={location}
-              onChange={(e) => {
-                setLocation(e.target.value);
-              }}
-            />
-          </LayoutContainer>
-          <LayoutContainer>
-            <label htmlFor='event-detail'>상세 설명</label>
-            <Textarea
-              id='event-detail'
-              placeholder='행사 관련 정보를 자유롭게 기재해주세요.'
-              onChange={(e) => setDescription(e.target.value)}
-              value={description}
-            ></Textarea>
-          </LayoutContainer>
-          <p> {missingInputMessage}</p>
-          <button type='submit'>저장</button>
-        </Form>
+        <ProductForm
+          product={{ imgSrc, productName, productType, startDate, endDate, location, description }}
+          setImgSrc={setImgSrc}
+          setProductType={setProductType}
+          setProductName={setProductName}
+          setStartDate={setStartDate}
+          setEndDate={setEndDate}
+          dateSelectionErrorMsg={dateSelectionErrorMsg}
+          setLocation={setLocation}
+          setDescription={setDescription}
+          onSubmit={submitProductForm}
+          missingInputMessage={missingInputMessage}
+        />
       </Container>
     </>
   );

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -1,65 +1,68 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { handleUploadImage } from '../../Utils/handleUploadImage';
+import { ProductForm } from '../../Components/Product/ProductForm';
+import { useProductData } from '../../Hooks/Product/useProductData';
+import { useSubmitProductForm } from '../../Hooks/Product/useSubmitProductForm';
 import { getProductDetail, editProduct } from '../../API/Product/ProductAPI';
 import useDateValidation from '../../Hooks/Product/useDateValidation';
-import _ from 'lodash';
-
 // Styled-Component 수정 예정
 import { Container } from '../../Components/Common/Container';
 import Gobackbtn from '../../Components/Common/GoBackbtn';
 import DefaultImg from '../../Assets/images/img-product-default.png';
-import {
-  Form,
-  Header,
-  ImgLayoutContainer,
-  ImageLabel,
-  Image,
-  LayoutContainer,
-  SelectedButton,
-  TextInput,
-  PeriodInputContainer,
-  PeriodInput,
-  Textarea,
-  StyledErrorMsg,
-} from '../../Components/Common/ProductSharedStyle';
+import { Header } from '../../Components/Common/ProductSharedStyle';
 
 const ProductEdit = () => {
   const navigate = useNavigate();
   const params = useParams();
   const productId = params.product_id;
 
-  const [imgSrc, setImgSrc] = useState({
-    product: {
-      url: DefaultImg,
-      alt: '',
-    },
-  });
-  const [productType, setProductType] = useState('');
-  const [productName, setProductName] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [location, setLocation] = useState('');
-  const [description, setDescription] = useState('');
-  const [missingInputMessage, setMissingInputMessage] = useState('');
+  const initialState = {
+    imgSrc: DefaultImg,
+    productType: '',
+    productName: '',
+    startDate: '',
+    endDate: '',
+    location: '',
+    description: '',
+    missingInputMessage: '',
+  };
+
+  const {
+    imgSrc,
+    setImgSrc,
+    productType,
+    setProductType,
+    productName,
+    setProductName,
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    location,
+    setLocation,
+    description,
+    setDescription,
+    missingInputMessage,
+    setMissingInputMessage,
+  } = useProductData(initialState);
 
   const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
 
-  //수정
   const getProductData = (data) => {
-    setProductType(data.product.itemName.includes('[f]') ? 'festival' : 'experience');
-    setProductName(data.product.itemName.slice(3));
+    const productType = data.product.itemName.slice(0, 3) === '[f]' ? 'festival' : 'experience';
+    const productName = data.product.itemName.slice(3);
+    const [description, location] = data.product.link.split('+[l]');
+    const period = data.product.price.toString();
+    const startDate = `${period.slice(0, 4)}-${period.slice(4, 6)}-${period.slice(6, 8)}`;
+    const endDate = `${period.slice(8, 12)}-${period.slice(12, 14)}-${period.slice(14, 16)}`;
 
-    const productImg = _.set({ ...imgSrc }, 'product.url', data.product.itemImage);
-    setImgSrc(productImg);
-
-    const [description, location] = data.product.link.split('+');
+    setProductType(productType);
+    setProductName(productName);
+    setImgSrc(data.product.itemImage);
     setDescription(description);
     setLocation(location);
-
-    const period = data.product.price.toString();
-    setStartDate(`${period.slice(0, 4)}-${period.slice(4, 6)}-${period.slice(6, 8)}`);
-    setEndDate(`${period.slice(8, 12)}-${period.slice(12, 14)}-${period.slice(14, 16)}`);
+    setStartDate(startDate);
+    setEndDate(endDate);
   };
 
   useEffect(() => {
@@ -69,26 +72,19 @@ const ProductEdit = () => {
 
     fetchProductInfo();
   }, []);
-  //
 
-  const handleChangeImage = async (e) => {
-    handleUploadImage(e, setImgSrc, 'product.url');
+  const productData = {
+    product: {
+      itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
+      price: progressPeriod,
+      link: `${description}+[l]${location}`,
+      itemImage: imgSrc,
+    },
   };
 
-  const submitProductForm = async (e) => {
-    e.preventDefault();
-
-    const productData = {
-      product: {
-        itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
-        price: progressPeriod,
-        link: `${description}+${location}`,
-        itemImage: imgSrc.product.url,
-      },
-    };
-
+  const validationChecks = () => {
     if (
-      !imgSrc.product.url ||
+      !imgSrc ||
       productName.length < 2 ||
       !startDate ||
       !endDate ||
@@ -98,113 +94,40 @@ const ProductEdit = () => {
       startDate > endDate
     ) {
       setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
+      return false;
     } else {
       setMissingInputMessage('');
-      await editProduct(productId, productData);
-      navigate('/product/list');
+      return true;
     }
   };
+
+  const submitProductForm = useSubmitProductForm(
+    editProduct,
+    navigate,
+    productData,
+    validationChecks,
+    productId,
+  );
 
   return (
     <Container>
       <Header>
         <Gobackbtn />
-        {/* <HeaderButton onClick={submitProductForm}>수정</HeaderButton> */}
       </Header>
       <h1 className='a11y-hidden'>상품 수정 페이지</h1>
-      <Form onSubmit={submitProductForm}>
-        <ImgLayoutContainer>
-          <h2>이미지 등록</h2>
-          <ImageLabel htmlFor='upload-file'>
-            <Image src={imgSrc.product.url || DefaultImg} alt={imgSrc.product.alt} />
-          </ImageLabel>
-          <input
-            className='a11y-hidden'
-            id='upload-file'
-            type='file'
-            accept='image/*'
-            onChange={handleChangeImage}
-          ></input>
-          <p>* 행사 관련 이미지를 등록해주세요.</p>
-        </ImgLayoutContainer>
-        <LayoutContainer>
-          <h2>카테고리</h2>
-          <div>
-            <SelectedButton
-              type='button'
-              onClick={() => setProductType('festival')}
-              selected={productType === 'festival'}
-            >
-              축제
-            </SelectedButton>
-            <SelectedButton
-              type='button'
-              onClick={() => setProductType('experience')}
-              selected={productType === 'experience'}
-            >
-              체험
-            </SelectedButton>
-          </div>
-        </LayoutContainer>
-        <LayoutContainer>
-          <label htmlFor='event-name'>행사명</label>
-          <TextInput
-            id='event-name'
-            type='text'
-            placeholder='2~22자 이내여야 합니다.'
-            onChange={(e) => setProductName(e.target.value)}
-            name='itemName'
-            value={productName}
-            minLength={2}
-            maxLength={22}
-          ></TextInput>
-        </LayoutContainer>
-        <LayoutContainer>
-          <label htmlFor='event-period'>행사 기간 </label>
-          <PeriodInputContainer>
-            <PeriodInput
-              type='date'
-              id='event-period'
-              onChange={(e) => setStartDate(e.target.value)}
-              value={startDate}
-              pattern='yyyy-MM-dd'
-              max='9999-12-31'
-            ></PeriodInput>
-            <PeriodInput
-              type='date'
-              id='event-period'
-              onChange={(e) => setEndDate(e.target.value)}
-              value={endDate}
-              pattern='yyyy-MM-dd'
-              max='9999-12-31'
-            ></PeriodInput>
-          </PeriodInputContainer>
-          <StyledErrorMsg>{dateSelectionErrorMsg}</StyledErrorMsg>
-        </LayoutContainer>
-        <LayoutContainer>
-          <label htmlFor='eventLocation'>행사 장소</label>
-          <TextInput
-            type='text'
-            id='eventLocation'
-            value={location}
-            onChange={(e) => {
-              setLocation(e.target.value);
-            }}
-          />
-        </LayoutContainer>
-        <LayoutContainer>
-          <label htmlFor='event-detail'>상세 설명</label>
-          <Textarea
-            id='event-detail'
-            name='link'
-            placeholder='행사 관련 정보를 자유롭게 기재해주세요.'
-            onChange={(e) => setDescription(e.target.value)}
-            value={description}
-          ></Textarea>
-        </LayoutContainer>
-        <p> {missingInputMessage}</p>
-        <button type='submit'>수정</button>
-      </Form>
+      <ProductForm
+        product={{ imgSrc, productName, productType, startDate, endDate, location, description }}
+        setImgSrc={setImgSrc}
+        setProductType={setProductType}
+        setProductName={setProductName}
+        setStartDate={setStartDate}
+        setEndDate={setEndDate}
+        dateSelectionErrorMsg={dateSelectionErrorMsg}
+        setLocation={setLocation}
+        setDescription={setDescription}
+        onSubmit={submitProductForm}
+        missingInputMessage={missingInputMessage}
+      />
     </Container>
   );
 };

--- a/moamoa/src/Utils/handleUploadImage.jsx
+++ b/moamoa/src/Utils/handleUploadImage.jsx
@@ -1,13 +1,9 @@
-import _ from 'lodash';
 import { uploadImage } from '../API/Image/ImageAPI';
 
-export const handleUploadImage = async (e, setter, path) => {
-  const imageFile = e.target.files[0];
-  if (!imageFile) {
-    return;
-  }
+export const handleUploadImage = async (imageFile) => {
   const response = await uploadImage(imageFile);
   const imageUrl = `https://api.mandarin.weniv.co.kr/${response.data.filename}`;
+  const imageAlt = response.data.originalname;
 
-  setter((prevState) => _.set({ ...prevState }, path, imageUrl));
+  return { imageUrl, imageAlt };
 };


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
+ 유지보수성을 높이기 위해 상품 등록과 수정 컴포넌트의 중복 로직을 분리했습니다.
+ 함수가 하나의 역할만 하도록 이미지 업로드 함수를 수정합니다.
+ 행사 등록, 행사 수정 시 product 객체의 link 속성 값에 ‘상세설명+[l]행사장소' 형태로 서버에 데이터를 보내도록 수정합니다.


### 작업 내역
1. 상품등록과 상품수정 컴포넌트 간에 중복 로직 분리
   - 공통 컴포넌트: ProductForm.jsx
   - 커스텀 훅: useProductData.jsx, useSubmitProductForm.jsx
   - useProductData 훅은 상품 데이터를 관리하고 useSubmitProductForm훅은 폼 제출을 처리합니다.

2. 이미지 업로드 함수 수정(handleUploadImage.jsx)
   - setter 함수를 제거하고 이미지 업로드 API 응답만 받아오도록 합니다.
   - 회원가입 시 프로필 설정, 상품 등록, 상품 수정에서 해당 함수를 사용했습니다.

3. 행사 등록, 행사 수정에서 link 속성값 변경
   - ‘상세설명+행사장소' => ‘상세설명+[l]행사장소'
   - 구분자 [l]은 location의 'l'입니다.


### 작업 후 기대 동작(스크린샷) 




### PR 특이 사항




### 특이 사항 :
Issue Number

close: # 301
