### PR TITLE
[♻️ Refactor] 상품 상세 페이지 행사 장소 추가

### DIFF
--- a/moamoa/src/Components/Modal/DeleteModal.jsx
+++ b/moamoa/src/Components/Modal/DeleteModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { deleteProduct } from '../../API/Product/ProductAPI';
@@ -7,20 +7,21 @@ import PropTypes from 'prop-types';
 import NoticeModal from './DeleteAlert';
 
 DeleteModal.propTypes = {
-  postid: PropTypes.string
+  postid: PropTypes.string,
+  setPostId: PropTypes.func,
+  setCloseFooter: PropTypes.func.isRequired
 };
 
-export default function DeleteModal({postid}) {
+export default function DeleteModal({postid,setPostId, setCloseFooter}) {
   const params = useParams();
   const navigate = useNavigate();
   const [delMadoal, setDelModal] = useState(true);
-  const [postId, setPostId] =  useState(postid)
   const location = useLocation();
   const post = location.pathname.slice(1, 5);
   const [showNoticeModal, setShowNoticeModal] = useState(true);
 
   // 게시글 상세 페이지에서 게시글 삭제
-  const handlePostDelete = () => deletePost(postId)
+  const handlePostDelete = () => deletePost(postid)
   const deletePostItem = async () => {
     await handlePostDelete();
     setShowNoticeModal(false);
@@ -28,7 +29,6 @@ export default function DeleteModal({postid}) {
       navigate(-1);
     }, 1000);
       setDelModal(false);
-      setPostId(null);
     };
 
   // myInfo 페이지에서 게시글 삭제
@@ -36,10 +36,10 @@ export default function DeleteModal({postid}) {
     await handlePostDelete();
     setShowNoticeModal(false);
     setDelModal(false);
+    setPostId(null);
     await setTimeout(() => {
       setDelModal(false);
-      setPostId(null);
-      window.location.reload();  
+      setCloseFooter(true)
     }, 1000);
   };
 
@@ -58,11 +58,9 @@ export default function DeleteModal({postid}) {
       if(post === "prof"){
         delMyPostListItem();
       } else if(post === "post"){
-        useEffect(()=>{ 
-          deletePostItem();
-        },[postId])
+        deletePostItem();
       } else {
-          deleteProducData();
+        deleteProducData();
       }      
     }
 

--- a/moamoa/src/Components/Modal/FooterModal.jsx
+++ b/moamoa/src/Components/Modal/FooterModal.jsx
@@ -9,12 +9,12 @@ import PropTypes from 'prop-types';
 FooterModal.propTypes = {
   postid: PropTypes.string,
   closeFooter: PropTypes.bool,
+  setPostId: PropTypes.func,
   setCloseFooter: PropTypes.func,
 };
 
-export default function FooterModal({ closeFooter, setCloseFooter, postid }) {
+export default function FooterModal({ closeFooter, setCloseFooter, postid, setPostId }) {
   const [showModal, setShowModal] = useState(true);
-  console.log(postid);
   const editUrl = `/post/edit/${postid}`;
 
   return (
@@ -32,7 +32,7 @@ export default function FooterModal({ closeFooter, setCloseFooter, postid }) {
           </Modal>
           {!showModal ? (
             <DeleteModal
-              postid={postid}
+              postid={postid} setPostId={setPostId} setCloseFooter={setCloseFooter}
             />
           ) : null}
         </ModalCont>

--- a/moamoa/src/Components/Post/PostList.jsx
+++ b/moamoa/src/Components/Post/PostList.jsx
@@ -14,7 +14,7 @@ export default function PostList({post, isLoading}) {
 
   return (
       <Posts>
-        <li>{post && isLoading ? <PostItem post={post}/>
+        <li>{post && !isLoading ? <PostItem post={post}/>
         :<PostItemSkeleton />}</li>
       </Posts>
   );

--- a/moamoa/src/Components/Post/PostMoreBtn.jsx
+++ b/moamoa/src/Components/Post/PostMoreBtn.jsx
@@ -12,7 +12,7 @@ PostMoreBtn.propTypes = {
 }
 
 export default function PostMoreBtn({btnData}) {
-  const postId = btnData?.postId;
+  const [postId,setPostId] = useState(btnData?.postId);
   const accountName = btnData?.accountName;
   const loginAccountName = useRecoilValue(accountNameAtom);
   const [showModal, setShowModal] = useState(true);
@@ -22,7 +22,7 @@ export default function PostMoreBtn({btnData}) {
   return (
     <>
       <MoreBtn onClick={openModal}><MoreImg src={more} alt="더보기" /></MoreBtn>
-      { !showModal && (loginAccountName === accountName)? <FooterModal postid={postId} closeFooter={showModal} setCloseFooter={setShowModal}/> : <ReportModal closemodal={showModal} setclosemodal={setShowModal} postid={postId}/>}
+      { !showModal && (loginAccountName === accountName)? <FooterModal postid={postId} closeFooter={showModal} setCloseFooter={setShowModal} setPostId={setPostId}/> : <ReportModal closemodal={showModal} setclosemodal={setShowModal} postid={postId}/>}
     </>
   )
 

--- a/moamoa/src/Components/Product/ProductContents.jsx
+++ b/moamoa/src/Components/Product/ProductContents.jsx
@@ -10,6 +10,10 @@ ProductContents.propTypes = {
 
 
 export default function ProductContents({productData}) {
+
+  const placeIndex = productData?.link.indexOf("+[l]")
+  console.log(productData?.link.slice(placeIndex+4));
+
   return (
     <>
       <FestivalImg src={productData.itemImage || ''} alt='행사' />
@@ -19,14 +23,14 @@ export default function ProductContents({productData}) {
         </FestivalTitle>
         <FestivalInfo>행사 소개</FestivalInfo>
         <FestivalDesc>
-          {productData?.link || '행사 상세 설명을 조회할 수 없습니다.'}
+          {productData?.link.slice(0,placeIndex) || '행사 상세 설명을 조회할 수 없습니다.'}
         </FestivalDesc>
         <FestivalInfo>행사 기간</FestivalInfo>
         <FestivalDesc>
           {productData ? productPeriod(productData): '행사 기간을 조회할 수 없습니다.'}
         </FestivalDesc>
         <FestivalInfo>행사 장소</FestivalInfo>
-        <FestaMap festaName={productData.itemName.slice(3)}/>
+        <FestaMap festaName={productData?.link.slice(placeIndex+4)}/>
       </InfoContainer>
     </>
   )

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -52,7 +52,7 @@ const ProductAdd = () => {
       product: {
         itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
         price: progressPeriod,
-        link: `${description}+${location}`,
+        link: `${description}+[l]${location}`,
         itemImage: imgSrc.product.url,
       },
     };


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
행사명으로 검색한 위치를 지도에 표기해 상세 주소가 명시되지 않는 문제가 있어 이를 수정했습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
상품 등록시 추가해준 행사 장소 데이터를 '+[l]' 구분자를 통해 잘라냈고, 이를 사용해 지도가 표시되도록 했습니다.
<img width="694" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/8a3ab50d-80b7-46b9-89a7-ebe20758fe1f">



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
주소-좌표간 변환을 통해 지도를 표시하면 아래와 같이 정확한 위치에 마커가 찍히지 않습니다. 
<img width="401" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/1f3c5a1f-9fc1-4eed-9763-d1329b92ec49">

키워드 검색으로 진행할 경우 너무 많은 마커가 생성됩니다..
<img width="402" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/6a4053a9-b071-4ff2-b1d3-e84c2ec04d10">




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
위의 두가지의 방법 중 어떻게 지도가 출력되게 하는게 좋을까요...? ㅠㅠ
1. 조금 어긋나더라도 하나의 마커만 출력
2. 키워드에 해당하는 모든 마커가 출력
의견 부탁드리겠습니다!



### 특이 사항 :
Issue Number

close: #303 
