### PR TITLE
[🔧 Fix] 상품(행사)저장 버튼 위치 조정

### DIFF
--- a/moamoa/src/Components/Common/ProductFormStyle.jsx
+++ b/moamoa/src/Components/Common/ProductFormStyle.jsx
@@ -35,7 +35,7 @@ const BtnHoverStyle = css`
 
 export const Form = styled.form`
   position: relative;
-  padding: 0 34px;
+
   margin-top: 80px;
   background-color: #fff;
   font-size: 13px;
@@ -47,7 +47,8 @@ export const Form = styled.form`
   }
 
   & > *:nth-child(7) {
-    margin-top: 10px;
+    margin-top: 20px;
+    margin-bottom: 100px;
   }
 
   h2,
@@ -97,6 +98,7 @@ export const Form = styled.form`
 
 export const ImgLayoutContainer = styled.div`
   position: relative;
+  padding: 0 34px;
 
   p {
     text-align: right;
@@ -127,7 +129,7 @@ export const ImageLabel = styled.label`
     width: 36px;
     height: 36px;
     border-radius: 50%;
-    right: 7px;
+    right: 40px;
     bottom: 30px;
     background: url(${UploadFile}) 0 0 / cover;
   }
@@ -142,6 +144,7 @@ export const Image = styled.img`
 
 export const LayoutContainer = styled.div`
   ${FlexColumn}
+  padding: 0 34px;
 `;
 
 export const Button = styled.button`
@@ -191,7 +194,8 @@ export const DateInput = styled.input`
 `;
 
 export const SubmitErrorMsg = styled.p`
-  text-align: right;
+  text-align: center;
+  font-weight: 600;
 `;
 
 export const SubmitBtn = styled.button`
@@ -202,16 +206,11 @@ export const SubmitBtn = styled.button`
   color: white;
 
   ${BtnHoverStyle}
-
-  width: 100%;
-  height: 34px;
-  border-radius: 32px;
-
-  //------------------------------- 기존 위치 코드
-  // width: 90px;
-  // position: fixed;
-  // top: 24px;
-  // left: 53.5%;
-  // transform: translate(24px, -53.5%);
-  // z-index: 99999;
+  position: fixed;
+  width: 390px;
+  height: 60px;
+  bottom: -25px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
 `;


### PR DESCRIPTION
### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
팀원 분들의 코멘트를 통해 새로운 대안이 떠올라서 아래와 같이 작업했습니다!



### 작업 내역
저장버튼이 하단에 고정되도록 수정합니다!   

사용자 경험, 컴포넌트 재사용성, 시맨틱한 마크업, 키보드 탭 순서 
4마리 토끼를 다 잡을 수 있는 방법이라 생각했습니다:)





### 작업 후 기대 동작(스크린샷) 
행사 등록 |행사 수정
--- | --- | 
![상품 등록](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/56d4781c-bd6e-4fe6-be7f-475ebe95a187) |![상품 수정](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/135303974/2748147f-6230-46ee-9aa0-3b3e1ddf94a8)|







### PR 특이 사항
버튼 크기가 적당한지 궁금합니다! 
하단 내비게이션과 똑같이 높이를 맞춘 상황입니당




### 특이 사항 :
Issue Number

close: # 310
