### PR TITLE
[🔧 Fix/ 🌈 Style]축제&체험 리스트 페이지 스타일 수정, 스플래쉬 로고 시간 수정,이미지 alt 삽입

### DIFF
--- a/moamoa/src/Components/Common/ChatMoreBtn.jsx
+++ b/moamoa/src/Components/Common/ChatMoreBtn.jsx
@@ -17,7 +17,7 @@ export default function ChatModal() {
   return (
     <>
       <Quitbtn onClick={openModal}>
-        <MoreImage src={MoreImg} />
+        <MoreImage src={MoreImg} alt="더보기 버튼"/>
       </Quitbtn>
       {modal && (
         <BgCont>

--- a/moamoa/src/Components/Common/ChatPhoto.jsx
+++ b/moamoa/src/Components/Common/ChatPhoto.jsx
@@ -8,7 +8,7 @@ ChatPhoto.propTypes = {
 export default function ChatPhoto(props) {
   return (
     <div>
-      <Photo src={props.src} alt='' />
+      <Photo src={props.src} alt='유저 프로필 사진' />
     </div>
   );
 }

--- a/moamoa/src/Components/Common/Container.jsx
+++ b/moamoa/src/Components/Common/Container.jsx
@@ -10,7 +10,6 @@ export const Container = styled.div`
   flex-direction: column;
   position: relative;
   background-color: #fff;
-  /* border: 1px solid black; */
 `;
 export const ContainerPercent = styled(Container)`
   height: 100%;

--- a/moamoa/src/Components/Common/FollowingUser.jsx
+++ b/moamoa/src/Components/Common/FollowingUser.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import Button from '../Common/Button';
-import PropTypes from 'prop-types'; // npm install prop-types 설치 필요
+import PropTypes from 'prop-types'; 
 import { useNavigate } from 'react-router-dom';
 
 FollowUser.propTypes = {

--- a/moamoa/src/Components/Splash/LoginModal.jsx
+++ b/moamoa/src/Components/Splash/LoginModal.jsx
@@ -8,7 +8,7 @@ export default function LoginModal() {
   useEffect(() => {
     const modalTimeout = setTimeout(() => {
       setModalActive(true);
-    }, 2000);
+    }, 3000);
     return () => clearTimeout(modalTimeout);
   }, []);
 

--- a/moamoa/src/Components/Splash/SplashLoginBtn.jsx
+++ b/moamoa/src/Components/Splash/SplashLoginBtn.jsx
@@ -47,7 +47,7 @@ export default function SplashLoginBtn() {
       navigate('/');
       setTimeout(() => {
         navigate('/home');
-      }, 1998);
+      }, 2998);
     } else {
       navigate('/');
     }

--- a/moamoa/src/Pages/Chat/ChatRoomAccount.jsx
+++ b/moamoa/src/Pages/Chat/ChatRoomAccount.jsx
@@ -109,6 +109,7 @@ export default function ChatRoomKim() {
   );
 }
 const ChatRoom = styled.div`
+  margin-top:47px;  
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -129,17 +130,6 @@ const ChatMessages = styled.div`
   padding: 20px;
 `;
 
-// const Message = styled.div`
-//   width: 220px;
-//   font-size: 14px;
-//   background-color: #ffffff;
-//   border: 1px solid #ddd;
-//   border-radius: 0px 30px 30px 30px;
-//   margin: 0px 10px 10px;
-//   padding: 10px 12px 12px;
-//   line-height: normal;
-//   box-sizing: border-box;
-// `;
 
 const InputArea = styled.div`
   display: flex;
@@ -187,14 +177,7 @@ const FileInput = styled.input`
   overflow: hidden;
   border: 0;
 `;
-// const UserName = styled.h2`
-//   display: block;
-//   margin-left: 8px;
-//   margin-bottom: 5px;
-//   font-size: 12px;
-//   color: gray;
-//   font-weight: 500;
-// `;
+
 const MyTalk = styled.p`
   width: 220px;
   font-size: 14px;

--- a/moamoa/src/Pages/Chat/ChatRoomDarkHorse.jsx
+++ b/moamoa/src/Pages/Chat/ChatRoomDarkHorse.jsx
@@ -121,6 +121,7 @@ export default function ChatRoomKim() {
   );
 }
 const ChatRoom = styled.div`
+  margin-top:47px;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/moamoa/src/Pages/Chat/ChatRoomKim.jsx
+++ b/moamoa/src/Pages/Chat/ChatRoomKim.jsx
@@ -5,7 +5,7 @@ import Header from '../../Components/Common/Header';
 import Photo from '../../Components/Common/ChatPhoto';
 import img from '../../Assets/images/followImg/fog.jpg';
 import iconImageButton from '../../Assets/icons/icon-img-button.svg';
-/* eslint-disable */
+
 export default function ChatRoomKim() {
   const [message, setMessage] = useState('');
   const [file, setFile] = useState(null);
@@ -61,7 +61,7 @@ export default function ChatRoomKim() {
       handleSendClick();
     }
   };
-  /* eslint-disable */
+  
   return (
     <Container>
       <Header type='chatFixedUser'></Header>
@@ -123,6 +123,7 @@ export default function ChatRoomKim() {
   );
 }
 const ChatRoom = styled.div`
+  margin-top:47px;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/moamoa/src/Pages/Chat/ChatRoomSumiDad.jsx
+++ b/moamoa/src/Pages/Chat/ChatRoomSumiDad.jsx
@@ -121,6 +121,7 @@ export default function ChatRoomKim() {
   );
 }
 const ChatRoom = styled.div`
+  margin-top:47px;
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/moamoa/src/Pages/Product/ProductList.jsx
+++ b/moamoa/src/Pages/Product/ProductList.jsx
@@ -6,7 +6,7 @@ import 'react-loading-skeleton/dist/skeleton.css';
 import ProductListSkeleton from '../../Components/Product/ProductListSkeleton';
 import ProductOutput from '../../Components/Product/ProductOutput';
 import styled from 'styled-components';
-import { ContainerPercent } from '../../Components/Common/Container';
+import { Container } from '../../Components/Common/Container';
 import Header from '../../Components/Common/Header';
 import Footer from '../../Components/Common/Footer';
 
@@ -35,22 +35,23 @@ export default function ProductList() {
   }, [token, setProduct]);
 
   return (
-    <ContainerPercent>
+    <Container>
       <Header type='home' />
       <ProductListWrap>
         {loading ? (
           <ProductListSkeleton />
-        ) : error ? (
+          ) : error ? (
           <p>Error:{error.message}</p>
-        ) : (
-          <ProductOutput />
-        )}
+          ) : (
+            <ProductOutput />
+            )}
       </ProductListWrap>
       <Footer></Footer>
-    </ContainerPercent>
+    </Container>
   );
 }
 
 const ProductListWrap = styled.div`
+  background-color:#fff;
   margin-top: 48px;
 `;


### PR DESCRIPTION
<!-- [🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
축제&체험 리스트 페이지를 축소했을때 푸터가 컨테이너 배경색과 이어지지 않는 문제점이 있었습니다.
로그인한 유저에게 moamoa 로고를 보여주는 시간이 짧았습니다.
채팅방 이미지의 alt가 들어있지 않았습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
축제&체험 리스트 페이지는 ProductListWrap에 배경색을 넣고
Container는 100vh로 수정했습니다.
스플래쉬 로고 시간 수정은 setTimeOut의 시간을 1초 늘렸습니다.





### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷 -->
축제&체험 리스트 수정 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/f2fc93ab-c708-4ff7-b5cd-3c731ecd1f06)

축제&체험 리스트 수정 후
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/fbf6a8d2-c946-4dfe-91b5-1f55e75fe88f)

채팅방 수정 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/31f3e4c1-4c82-46a3-a863-d5a23fbb6635)

채팅방 수정 후
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/6cab5944-e5db-4f53-a504-1dd98583221a)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #319 #318 #295 

close: # 자기가 개발 전에 올린 이슈
