### PR TITLE
[♻️ Refactor]행사&축제 페이지 코드 컴포넌트 분리와 행사 기간 시맨틱 태그 변경

### DIFF
--- a/moamoa/src/Components/Product/ProductOutput.jsx
+++ b/moamoa/src/Components/Product/ProductOutput.jsx
@@ -6,35 +6,16 @@ import backgroundMoamoa from '../../Assets/images/backgroundMoamoa.png';
 import { Link } from 'react-router-dom';
 import ProductImgBox from '../../Components/Common/ProductImgBox';
 import TopNavigation from '../../Components/Product/TopNavigation';
-import { festivalActiveState, experienceActiveState } from '../../Recoil/ProductTypeStateAtom';
-
-function formatEventDate(dateString) {
-  const startYear = dateString.slice(2, 4);
-  const startMonth = dateString.slice(4, 6);
-  const startDay = dateString.slice(6, 8);
-  const endYear = dateString.slice(10, 12);
-  const endMonth = dateString.slice(12, 14);
-  const endDay = dateString.slice(14, 16);
-
-  return `행사기간: ${startYear}.${startMonth}.${startDay} ~ ${endYear}.${endMonth}.${endDay}`;
-}
+import { filterActive } from './filterActive';
+import { formatEventStartDate } from './formatEventDate';
+import { formatEventEndDate } from './formatEventDate';
+import { semanticStartDate } from './formatEventDate';
+import { semanticEventEndDate } from './formatEventDate';
 
 export default function ProductBundle() {
   const [product] = useRecoilState(ProductAtom);
-  const [festivalActive, experienceActive] = useRecoilState(
-    festivalActiveState,
-    experienceActiveState,
-  );
-  const filterActive = (item) => {
-    if (festivalActive && item.itemName.includes('[f]')) {
-      return true;
-    }
-    if (!festivalActive && experienceActive && item.itemName.includes('[e]')) {
-      return true;
-    }
-    return false;
-  };
   const filteredProducts = product.filter(filterActive);
+
   return (
     <>
       <TopNavigation />
@@ -44,8 +25,13 @@ export default function ProductBundle() {
             <Link to={`/product/detail/${item._id}`} key={index}>
               <ProductImgBox src={item.itemImage} />
             </Link>
-            <p className='itemName'>{item.itemName.replace('[f]', '').replace('[e]', '')}</p>
-            <p className='itemDate'>{formatEventDate(item.price.toString())}</p>
+            <h2 className='itemName'>{item.itemName.replace('[f]', '').replace('[e]', '')}</h2>
+            <time className='itemDate' dateTime={semanticStartDate(item.price.toString())}>
+              {formatEventStartDate(item.price.toString())}
+            </time>
+            <time className='itemDate' dateTime={semanticEventEndDate(item.price.toString())}>
+              {formatEventEndDate(item.price.toString())}
+            </time>
           </ProductBox>
         ))}
       </ProductContainer>

--- a/moamoa/src/Components/Product/filterActive.js
+++ b/moamoa/src/Components/Product/filterActive.js
@@ -1,0 +1,18 @@
+import { useRecoilState } from 'recoil';
+import { festivalActiveState, experienceActiveState } from '../../Recoil/ProductTypeStateAtom';
+
+export function filterActive(item) {
+  const [festivalActive, experienceActive] = useRecoilState(
+    festivalActiveState,
+    experienceActiveState,
+  );
+
+  if (festivalActive && item.itemName.includes('[f]')) {
+    return true;
+  }
+
+  if (!festivalActive && experienceActive && item.itemName.includes('[e]')) {
+    return true;
+  }
+  return false;
+}

--- a/moamoa/src/Components/Product/formatEventDate.js
+++ b/moamoa/src/Components/Product/formatEventDate.js
@@ -1,0 +1,28 @@
+export function formatEventStartDate(dateString) {
+  const startYear = dateString.slice(2, 4);
+  const startMonth = dateString.slice(4, 6);
+  const startDay = dateString.slice(6, 8);
+
+  return `행사기간: ${startYear}.${startMonth}.${startDay} ~`;
+}
+export function formatEventEndDate(dateString) {
+  const endYear = dateString.slice(10, 12);
+  const endMonth = dateString.slice(12, 14);
+  const endDay = dateString.slice(14, 16);
+
+  return `${endYear}.${endMonth}.${endDay}`;
+}
+export function semanticStartDate(dateString) {
+  const startYear = dateString.slice(0, 4);
+  const startMonth = dateString.slice(4, 6);
+  const startDay = dateString.slice(6, 8);
+
+  return `${startYear}-${startMonth}-${startDay}`;
+}
+export function semanticEventEndDate(dateString) {
+  const endYear = dateString.slice(8, 12);
+  const endMonth = dateString.slice(12, 14);
+  const endDay = dateString.slice(14, 16);
+
+  return `${endYear}-${endMonth}-${endDay}`;
+}


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
productOutput.jsx의 코드에서 재사용 할 수 있는 코드를 분리했습니다.
행사명과 행사기간의 태그가 p태그로 있었습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
filterActive 부분을 떼어서 .js 파일로 분리했습니다.
행사기간 부분도 재사용성을 높이기 위해 .js 파일로 분리하였고,
사용자에게 시각적으로 보이는 부분의 시작기간 ~ 끝기간 함수와
시맨틱 태그를 위한 함수 2개를 생성하였습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->

#### productOutput.jsx 컴포넌트 분리 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/e57f637f-db83-4c0a-8a78-cee78e45cc89)

#### productOutput.jsx 컴포넌트 분리 후
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/62b01b28-dd8f-423d-957e-fd54ac805cc4)


#### 태그 변경 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/b797f5a5-7aaf-431e-b4a3-507a65c7eb51)
#### 태그 변경 후 
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/efcf879d-a8b5-4638-974c-a1d7e8f8db37)
dateTime에 날짜를 하나씩 담기위해 태그를 두 개로 변경했습니다.

#### formatEventDate.js
(formatEventStartDate,formatEventEndDate = 시각적으로 보이는 함수)
(semanticStartDate,semanticEndDate = 시맨틱 태그를 위해 dateTime에 넣을 함수)
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/9249f703-5526-4fa2-8259-010793a0463e)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
productOutput.jsx 컴포넌트 분리 후 return 부분의 
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/434f8766-0d89-45cf-9acf-5ed3f525bba8)
이 부분을 깔끔하게 만들 방법을 찾지 못했습니다.



### 특이 사항 :
Issue Number #317 

close: # 자기가 개발 전에 올린 이슈
