### PR TITLE
[🌈 Style]상품&축제 리스트의 열을 1 줄로 변경

### DIFF
--- a/moamoa/src/Components/Common/ProductImgBox.jsx
+++ b/moamoa/src/Components/Common/ProductImgBox.jsx
@@ -5,11 +5,21 @@ import PropTypes from 'prop-types'; // npm install prop-types 설치 필요
 ProductImgBox.propTypes = {
   src: PropTypes.string.isRequired,
 };
+ProductListImgBox.propTypes = {
+  src: PropTypes.string.isRequired,
+};
 
 export default function ProductImgBox(props) {
   return (
     <div>
       <ImgBox src={props.src} />
+    </div>
+  );
+}
+export function ProductListImgBox(props) {
+  return (
+    <div>
+      <ProductListPoster src={props.src} />
     </div>
   );
 }
@@ -19,4 +29,10 @@ const ImgBox = styled.img.attrs({ alt: '축제포스터' })`
   border: 1px solid #dbdbdb;
   width: 172px;
   height: 110px;
+`;
+
+const ProductListPoster = styled(ImgBox)`
+  width: 350px;
+  height: 140px;
+  object-fit: fill;
 `;

--- a/moamoa/src/Components/Common/ProductImgBox.jsx
+++ b/moamoa/src/Components/Common/ProductImgBox.jsx
@@ -32,7 +32,7 @@ const ImgBox = styled.img.attrs({ alt: '축제포스터' })`
 `;
 
 const ProductListPoster = styled(ImgBox)`
-  width: 350px;
+  width: 370px;
   height: 140px;
   object-fit: fill;
 `;

--- a/moamoa/src/Components/Product/ProductOutput.jsx
+++ b/moamoa/src/Components/Product/ProductOutput.jsx
@@ -40,10 +40,10 @@ export default function ProductBundle() {
 }
 export const ProductContainer = styled.div`
   max-width: 100%;
-  margin: 0 auto;
+  margin: 10px auto;
   display: grid;
   grid-template-columns: repeat(1, 1fr);
-  gap: 30px;
+  gap: 20px;
   flex: 1;
 
   padding-bottom: 150px;

--- a/moamoa/src/Components/Product/ProductOutput.jsx
+++ b/moamoa/src/Components/Product/ProductOutput.jsx
@@ -4,7 +4,7 @@ import { useRecoilState } from 'recoil';
 import { ProductAtom } from '../../Pages/Product/ProductList';
 import backgroundMoamoa from '../../Assets/images/backgroundMoamoa.png';
 import { Link } from 'react-router-dom';
-import ProductImgBox from '../../Components/Common/ProductImgBox';
+import { ProductListImgBox } from '../../Components/Common/ProductImgBox';
 import TopNavigation from '../../Components/Product/TopNavigation';
 import { filterActive } from './filterActive';
 import { formatEventStartDate } from './formatEventDate';
@@ -23,7 +23,7 @@ export default function ProductBundle() {
         {filteredProducts.map((item, index) => (
           <ProductBox key={index}>
             <Link to={`/product/detail/${item._id}`} key={index}>
-              <ProductImgBox src={item.itemImage} />
+              <ProductListImgBox src={item.itemImage} />
             </Link>
             <h2 className='itemName'>{item.itemName.replace('[f]', '').replace('[e]', '')}</h2>
             <time className='itemDate' dateTime={semanticStartDate(item.price.toString())}>
@@ -42,22 +42,23 @@ export const ProductContainer = styled.div`
   max-width: 100%;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 30px;
   flex: 1;
+
   padding-bottom: 150px;
   background-image: url(${backgroundMoamoa});
   background-repeat: no-repeat;
   background-position: 110% 91%;
   background-position: bottom 8rem right 0px;
-  grid-template-rows: 160px;
 `;
 export const ProductBox = styled.div`
-  max-width: 172px;
+  /* max-width: 190px; */
   margin: 0 auto;
 
   .itemName {
-    font-size: 14px;
+    width: 300px;
+    font-size: 16px;
     margin: 12px 0 6px 4px;
     font-weight: 500;
   }


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->




### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/77d2c491-0bca-4744-909e-6b94e2c2763f)
프로필의 진행중인 행사에서 이미지 컴포넌트를 같이 사용하여 ProductImgBox를 확장하여 ProductListImgBox 컴포넌트를 사용하여 축제&체험 리스트의 이미지 크기를 조정하고 한 줄로 바꾸었습니다.
2열
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/d1965116-ad70-483b-8ae1-a265c20c6c0d)
1열
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/1af6e78b-ea36-4b1b-a053-ee7b6d4a62a9)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
날짜를 우측으로 둘 경우 "아침고요수목원 오색별빛정원전"과 같은 축제의 이름이 길면 날짜와 겹쳐서 보기 좋지않아 
이름과 날짜는 원래 형식으로 사용했습니다.
피드백 주시면 수정하겠습니다!!



### 특이 사항 :
Issue Number

close: # 자기가 개발 전에 올린 이슈
