### PR TITLE
[🌈 Style]검색 실패 이미지 중앙 배치, 뒤로가기 버튼 밀림 수정, 유저 검색 iuput 크기 수정, input 포커스 보더색 변경

### DIFF
--- a/moamoa/src/Components/Common/HeaderComponents.jsx
+++ b/moamoa/src/Components/Common/HeaderComponents.jsx
@@ -154,12 +154,11 @@ const ChatUserName = styled.h2`
 `;
 const HeaderSearchContainer = styled.header`
   display: flex;
-  justify-content: space-around;
+  justify-content: center;
   height: 48px;
   min-height: 48px;
   max-height: 48px;
   width: 390px;
-
   position: fixed;
   background-color: #fff;
   border-bottom: 1px solid #dbdbdb;
@@ -169,15 +168,19 @@ const HeaderSearchContainer = styled.header`
 
   img {
     cursor: pointer;
-    padding-right: 14px;
+    padding-right: 8px;
     padding-bottom: 2px;
   }
   input {
     background-color: #f2f2f2;
-    width: 316px;
+    width: 340px;
     height: 32px;
     border-radius: 32px;
     padding-left: 20px;
     box-sizing: border-box;
+    &:focus {
+      outline: none;
+      border: 1px solid #797979;
+    }
   }
 `;

--- a/moamoa/src/Components/Search/NotFound.jsx
+++ b/moamoa/src/Components/Search/NotFound.jsx
@@ -11,16 +11,14 @@ export default function NotFound() {
 }
 const NotFoundContainer = styled.div`
   width: 100%;
-  height: 100%;
+  height: 85%;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-
+  justify-content: center;
   img {
     width: 120px;
-    margin-block: 60px 20px;
-    transform: translateX(-5%);
+    margin-bottom: 20px;
   }
   p {
     font-size: 20px;

--- a/moamoa/src/Pages/Search/Search.jsx
+++ b/moamoa/src/Pages/Search/Search.jsx
@@ -82,9 +82,11 @@ export default function Search() {
 }
 
 const SearchListWrap = styled.div`
+  height: 100%;
   margin-top: 48px;
   padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  position: relative;
 `;


### PR DESCRIPTION
…cus border color 수정

<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
뒤로가기 버튼이 다른 페이지와 다른 위치에 있었습니다.
인풋 크기가 작은 의견과 검색 실패 이미지의 위치가 애매한 의견이 있었습니다.




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
검색 실패 이미지의 위치를 중앙 배치 했습니다.
인풋의 크기를 늘렸습니다.
뒤로가기 버튼의 위치를 다른 페이지와 맞추었습니다.





### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
수정 전 
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/5e8c1c6c-5062-427c-95b6-fbeaf5d408a5)
수정 후
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/d0107bea-8993-4230-a3d9-315247e73917)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #327 

close: # 자기가 개발 전에 올린 이슈
