### PR TITLE
[🔧 Fix / ♻️ Refactor] 상품 등록, 상품 수정 폼 미입력 정보 확인 요청 방식 수정 / 공통 로직 추출

### DIFF
--- a/moamoa/src/Components/Common/ProductFormStyle.jsx
+++ b/moamoa/src/Components/Common/ProductFormStyle.jsx
@@ -66,6 +66,7 @@ export const Form = styled.form`
     border-radius: 5px;
     ${BorderStyle}
     letter-spacing: 1.5px;
+    margin-bottom: 100px;
   }
 
   input[type='text']::-webkit-input-placeholder {
@@ -149,10 +150,6 @@ export const LayoutContainer = styled.div`
     margin-bottom: 35px;
   }
 
-  &:last-of-type {
-    margin-bottom: 100px;
-  }
-
   .category-container {
     display: flex;
     justify-content: space-between;
@@ -208,11 +205,6 @@ export const DateInput = styled.input`
     border-width: thin;
   }
 `;
-
-// export const SubmitErrorMsg = styled.p`
-//   text-align: center;
-//   font-weight: 600;
-// `;
 
 export const SubmitBtn = styled.button`
   background-color: ${(props) => (props.$isfilled ? `${COLORS.primary}` : `${COLORS.darkgray}`)};

--- a/moamoa/src/Components/Modal/RequiredInputModal.jsx
+++ b/moamoa/src/Components/Modal/RequiredInputModal.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+import MoaYellow from '../../Assets/icons/character-yellow.png';
+
+export default function RequiredInputModal() {
+  return (
+    <>
+      {
+        <BackGround>
+          <Cont image={MoaYellow}>
+            <NoticeText role='alert'>입력하지 않은 정보가 있습니다.</NoticeText>
+          </Cont>
+        </BackGround>
+      }
+    </>
+  );
+}
+
+const BackGround = styled.div`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  left: 0;
+  top: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 100;
+`;
+
+const Cont = styled.div`
+  width: 26rem;
+  height: 5rem;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0px 4px 3px 0px rgba(0, 0, 0, 0.15);
+  position: fixed;
+  left: 50%;
+  top: 20%;
+  transform: translate(-50%);
+  box-sizing: border-box;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  animation: fadein 0.3s;
+  @keyframes fadein {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  &::before {
+    content: '';
+    width: 3.8rem;
+    height: 3.9rem;
+    display: block;
+    background-image: ${(props) => `url(${props.image})`};
+    background-size: 3.8rem 3.9rem;
+  }
+`;
+
+const NoticeText = styled.p`
+  font-size: 1.4rem;
+  text-align: center;
+`;

--- a/moamoa/src/Components/Product/ProductForm.jsx
+++ b/moamoa/src/Components/Product/ProductForm.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import useDateValidation from '../../Hooks/Product/useDateValidation';
+import { uploadProduct } from '../../API/Product/ProductAPI';
+import { editProduct } from '../../API/Product/ProductAPI';
 
 import {
   Form,
@@ -21,17 +25,73 @@ export function ProductForm({
   setProductName,
   setStartDate,
   setEndDate,
-  dateSelectionErrorMsg,
   setLocation,
   setDescription,
-  onSubmit,
   showModal,
+  setShowModal,
   imgData,
   onCancel,
   onSelectFile,
   setCroppedImageFor,
   isOpen,
+  editMode,
+  productId,
 }) {
+  const navigate = useNavigate();
+
+  const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(
+    product.startDate,
+    product.endDate,
+  );
+
+  const productData = {
+    product: {
+      itemName:
+        product.productType === 'festival'
+          ? `[f]${product.productName}`
+          : `[e]${product.productName}`,
+      price: progressPeriod,
+      link: `${product.description}+[l]${product.location}`,
+      itemImage: imgData.croppedImageUrl ? imgData.croppedImageUrl : imgData.imageUrl,
+    },
+  };
+
+  const validationChecks = () => {
+    if (
+      product.productName.length < 2 ||
+      !product.startDate ||
+      !product.endDate ||
+      !product.location ||
+      !product.description ||
+      !product.productType ||
+      product.startDate > product.endDate
+    ) {
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+
+    if (!validationChecks()) {
+      setShowModal(true);
+      setTimeout(() => {
+        setShowModal(false);
+      }, 1000);
+      return;
+    }
+
+    if (!editMode) {
+      await uploadProduct(productData);
+    } else if (editMode) {
+      await editProduct(productId, productData);
+    }
+
+    navigate('/product/list');
+  };
+
   const isFilled =
     product.productName !== '' &&
     product.productType !== '' &&
@@ -170,19 +230,20 @@ export function ProductForm({
 
 ProductForm.propTypes = {
   product: PropTypes.object.isRequired,
-  onSubmit: PropTypes.func.isRequired,
   setProductType: PropTypes.func.isRequired,
   setProductName: PropTypes.func.isRequired,
   setStartDate: PropTypes.func.isRequired,
   setEndDate: PropTypes.func.isRequired,
-  dateSelectionErrorMsg: PropTypes.string,
   setLocation: PropTypes.func.isRequired,
   setDescription: PropTypes.func.isRequired,
   showModal: PropTypes.bool,
+  setShowModal: PropTypes.func,
   imgData: PropTypes.any.isRequired,
   selectedImage: PropTypes.any,
   onCancel: PropTypes.any.isRequired,
   onSelectFile: PropTypes.any.isRequired,
   setCroppedImageFor: PropTypes.any.isRequired,
   isOpen: PropTypes.bool,
+  editMode: PropTypes.bool,
+  productId: PropTypes.string,
 };

--- a/moamoa/src/Components/Product/ProductForm.jsx
+++ b/moamoa/src/Components/Product/ProductForm.jsx
@@ -10,10 +10,10 @@ import {
   Button,
   TextInput,
   DateInput,
-  // SubmitErrorMsg,
   SubmitBtn,
 } from '../../Components/Common/ProductFormStyle';
 import ImageCropModal from '../Modal/ImageCropModal';
+import RequiredInputModal from '../Modal/RequiredInputModal';
 
 export function ProductForm({
   product,
@@ -25,7 +25,7 @@ export function ProductForm({
   setLocation,
   setDescription,
   onSubmit,
-  // missingInputMessage,
+  showModal,
   imgData,
   onCancel,
   onSelectFile,
@@ -160,12 +160,10 @@ export function ProductForm({
           aria-describedby='eventDetail'
         ></textarea>
       </LayoutContainer>
-      {/* <SubmitErrorMsg role='alert' className='error-msg'>
-        {missingInputMessage}
-      </SubmitErrorMsg> */}
       <SubmitBtn type='submit' $isfilled={isFilled}>
         저장
       </SubmitBtn>
+      {showModal && <RequiredInputModal />}
     </Form>
   );
 }
@@ -180,7 +178,7 @@ ProductForm.propTypes = {
   dateSelectionErrorMsg: PropTypes.string,
   setLocation: PropTypes.func.isRequired,
   setDescription: PropTypes.func.isRequired,
-  // missingInputMessage: PropTypes.string,
+  showModal: PropTypes.bool,
   imgData: PropTypes.any.isRequired,
   selectedImage: PropTypes.any,
   onCancel: PropTypes.any.isRequired,

--- a/moamoa/src/Hooks/Product/useProductData.jsx
+++ b/moamoa/src/Hooks/Product/useProductData.jsx
@@ -7,11 +7,12 @@ export const useProductData = (initialState) => {
   const [endDate, setEndDate] = useState(initialState.endDate);
   const [location, setLocation] = useState(initialState.location);
   const [description, setDescription] = useState(initialState.description);
-  const [missingInputMessage, setMissingInputMessage] = useState(initialState.missingInputMessage);
 
   const [isOpen, setIsOpen] = useState(false);
   const [imgData, setImgData] = useState(initialState.image);
   const [prevImgData, setPrevImgData] = useState('');
+
+  const [showModal, setShowModal] = useState(false);
 
   return {
     productType,
@@ -26,13 +27,13 @@ export const useProductData = (initialState) => {
     setLocation,
     description,
     setDescription,
-    missingInputMessage,
-    setMissingInputMessage,
     isOpen,
     setIsOpen,
     imgData,
     setImgData,
     prevImgData,
     setPrevImgData,
+    showModal,
+    setShowModal,
   };
 };

--- a/moamoa/src/Hooks/Product/useProductData.jsx
+++ b/moamoa/src/Hooks/Product/useProductData.jsx
@@ -13,6 +13,7 @@ export const useProductData = (initialState) => {
   const [prevImgData, setPrevImgData] = useState('');
 
   const [showModal, setShowModal] = useState(false);
+  const [editMode, setEditMode] = useState(false);
 
   return {
     productType,
@@ -35,5 +36,7 @@ export const useProductData = (initialState) => {
     setPrevImgData,
     showModal,
     setShowModal,
+    editMode,
+    setEditMode,
   };
 };

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -1,16 +1,11 @@
-import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useEffect } from 'react';
 import { ProductForm } from '../../Components/Product/ProductForm';
 import { useProductData } from '../../Hooks/Product/useProductData';
-import { uploadProduct } from '../../API/Product/ProductAPI';
-import useDateValidation from '../../Hooks/Product/useDateValidation';
 import { Container } from '../../Components/Common/Container';
 import { HeaderSubmitProduct } from '../../Components/Common/HeaderComponents';
 import DefaultImg from '../../Assets/images/img-product-default.png';
 
 const ProductAdd = () => {
-  const navigate = useNavigate();
-
   const initialState = {
     productType: '',
     productName: '',
@@ -45,7 +40,13 @@ const ProductAdd = () => {
     setPrevImgData,
     showModal,
     setShowModal,
+    editMode,
+    setEditMode,
   } = useProductData(initialState);
+
+  useEffect(() => {
+    setEditMode(false);
+  }, []);
 
   const onCancel = () => {
     setImgData((prevImage) => ({
@@ -78,48 +79,6 @@ const ProductAdd = () => {
     }
   };
 
-  const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
-
-  const productData = {
-    product: {
-      itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
-      price: progressPeriod,
-      link: `${description}+[l]${location}`,
-      itemImage: imgData.croppedImageUrl ? imgData.croppedImageUrl : imgData.imageUrl,
-    },
-  };
-
-  const validationChecks = () => {
-    if (
-      productName.length < 2 ||
-      !startDate ||
-      !endDate ||
-      !location ||
-      !description ||
-      !productType ||
-      startDate > endDate
-    ) {
-      return false;
-    } else {
-      return true;
-    }
-  };
-
-  const onSubmit = async (e) => {
-    e.preventDefault();
-
-    if (!validationChecks()) {
-      setShowModal(true);
-      setTimeout(() => {
-        setShowModal(false);
-      }, 1000);
-      return;
-    }
-
-    await uploadProduct(productData);
-    navigate('/product/list');
-  };
-
   return (
     <>
       <Container>
@@ -131,16 +90,16 @@ const ProductAdd = () => {
           setProductName={setProductName}
           setStartDate={setStartDate}
           setEndDate={setEndDate}
-          dateSelectionErrorMsg={dateSelectionErrorMsg}
           setLocation={setLocation}
           setDescription={setDescription}
-          onSubmit={onSubmit}
           showModal={showModal}
+          setShowModal={setShowModal}
           imgData={imgData}
           onCancel={onCancel}
           onSelectFile={onSelectFile}
           setCroppedImageFor={setCroppedImageFor}
           isOpen={isOpen}
+          editMode={editMode}
         />
       </Container>
     </>

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -18,7 +18,6 @@ const ProductAdd = () => {
     endDate: '',
     location: '',
     description: '',
-    missingInputMessage: '',
     image: {
       imageUrl: DefaultImg,
       croppedImageUrl: null,
@@ -38,14 +37,14 @@ const ProductAdd = () => {
     setLocation,
     description,
     setDescription,
-    missingInputMessage,
-    setMissingInputMessage,
     isOpen,
     setIsOpen,
     imgData,
     setImgData,
     prevImgData,
     setPrevImgData,
+    showModal,
+    setShowModal,
   } = useProductData(initialState);
 
   const onCancel = () => {
@@ -100,10 +99,8 @@ const ProductAdd = () => {
       !productType ||
       startDate > endDate
     ) {
-      setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
       return false;
     } else {
-      setMissingInputMessage('');
       return true;
     }
   };
@@ -112,6 +109,10 @@ const ProductAdd = () => {
     e.preventDefault();
 
     if (!validationChecks()) {
+      setShowModal(true);
+      setTimeout(() => {
+        setShowModal(false);
+      }, 1000);
       return;
     }
 
@@ -134,7 +135,7 @@ const ProductAdd = () => {
           setLocation={setLocation}
           setDescription={setDescription}
           onSubmit={onSubmit}
-          missingInputMessage={missingInputMessage}
+          showModal={showModal}
           imgData={imgData}
           onCancel={onCancel}
           onSelectFile={onSelectFile}

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -1,15 +1,13 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ProductForm } from '../../Components/Product/ProductForm';
 import { useProductData } from '../../Hooks/Product/useProductData';
-import { getProductDetail, editProduct } from '../../API/Product/ProductAPI';
-import useDateValidation from '../../Hooks/Product/useDateValidation';
+import { getProductDetail } from '../../API/Product/ProductAPI';
 import { Container } from '../../Components/Common/Container';
 import DefaultImg from '../../Assets/images/img-product-default.png';
 import { HeaderSubmitProduct } from '../../Components/Common/HeaderComponents';
 
 const ProductEdit = () => {
-  const navigate = useNavigate();
   const params = useParams();
   const productId = params.product_id;
 
@@ -47,6 +45,8 @@ const ProductEdit = () => {
     setPrevImgData,
     showModal,
     setShowModal,
+    editMode,
+    setEditMode,
   } = useProductData(initialState);
 
   const onCancel = () => {
@@ -81,8 +81,6 @@ const ProductEdit = () => {
     }
   };
 
-  const { progressPeriod, dateSelectionErrorMsg } = useDateValidation(startDate, endDate);
-
   const getProductData = (data) => {
     const period = data.product.price.toString();
 
@@ -101,47 +99,8 @@ const ProductEdit = () => {
     };
 
     fetchProductInfo();
+    setEditMode(true);
   }, []);
-
-  const productData = {
-    product: {
-      itemName: productType === 'festival' ? `[f]${productName}` : `[e]${productName}`,
-      price: progressPeriod,
-      link: `${description}+[l]${location}`,
-      itemImage: imgData.croppedImageUrl ? imgData.croppedImageUrl : imgData.imageUrl,
-    },
-  };
-
-  const validationChecks = () => {
-    if (
-      productName.length < 2 ||
-      !startDate ||
-      !endDate ||
-      !location ||
-      !description ||
-      !productType ||
-      startDate > endDate
-    ) {
-      return false;
-    } else {
-      return true;
-    }
-  };
-
-  const onSubmit = async (e) => {
-    e.preventDefault();
-
-    if (!validationChecks()) {
-      setShowModal(true);
-      setTimeout(() => {
-        setShowModal(false);
-      }, 1000);
-      return;
-    }
-
-    await editProduct(productId, productData);
-    navigate('/product/list');
-  };
 
   return (
     <Container>
@@ -153,16 +112,17 @@ const ProductEdit = () => {
         setProductName={setProductName}
         setStartDate={setStartDate}
         setEndDate={setEndDate}
-        dateSelectionErrorMsg={dateSelectionErrorMsg}
         setLocation={setLocation}
         setDescription={setDescription}
-        onSubmit={onSubmit}
         showModal={showModal}
+        setShowModal={setShowModal}
         imgData={imgData}
         onCancel={onCancel}
         onSelectFile={onSelectFile}
         setCroppedImageFor={setCroppedImageFor}
         isOpen={isOpen}
+        editMode={editMode}
+        productId={productId}
       />
     </Container>
   );

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -20,7 +20,6 @@ const ProductEdit = () => {
     endDate: '',
     location: '',
     description: '',
-    missingInputMessage: '',
     image: {
       imageUrl: DefaultImg,
       croppedImageUrl: null,
@@ -40,14 +39,14 @@ const ProductEdit = () => {
     setLocation,
     description,
     setDescription,
-    missingInputMessage,
-    setMissingInputMessage,
     isOpen,
     setIsOpen,
     imgData,
     setImgData,
     prevImgData,
     setPrevImgData,
+    showModal,
+    setShowModal,
   } = useProductData(initialState);
 
   const onCancel = () => {
@@ -87,8 +86,6 @@ const ProductEdit = () => {
   const getProductData = (data) => {
     const period = data.product.price.toString();
 
-    console.log(data);
-
     setProductType(data.product.itemName.slice(0, 3) === '[f]' ? 'festival' : 'experience');
     setProductName(data.product.itemName.slice(3));
     setImgData((prevImg) => ({ ...prevImg, imageUrl: data.product.itemImage }));
@@ -125,10 +122,8 @@ const ProductEdit = () => {
       !productType ||
       startDate > endDate
     ) {
-      setMissingInputMessage('입력하지 않은 정보가 있습니다. 다시 확인해주세요.');
       return false;
     } else {
-      setMissingInputMessage('');
       return true;
     }
   };
@@ -137,6 +132,10 @@ const ProductEdit = () => {
     e.preventDefault();
 
     if (!validationChecks()) {
+      setShowModal(true);
+      setTimeout(() => {
+        setShowModal(false);
+      }, 1000);
       return;
     }
 
@@ -158,7 +157,7 @@ const ProductEdit = () => {
         setLocation={setLocation}
         setDescription={setDescription}
         onSubmit={onSubmit}
-        missingInputMessage={missingInputMessage}
+        showModal={showModal}
         imgData={imgData}
         onCancel={onCancel}
         onSelectFile={onSelectFile}


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유

1. 기존에는 사용자가 폼 제출 시 필수 정보를 미입력한다면 확인 요청을 보낼 때 저장 버튼 위에 메세지가 출력 되도록 했습니다. 하지만 스크롤 상 화면에 메세지가 안 보이는 경우가 있다는 것을 인지하게 되었고 이에 알림 모달로 방식을 수정했습니다.
2. 상품 등록과 상품 수정 컴포넌트 간의 공통 로직을 추출하여 공통 컴포넌트로 사용 중이던 ProductForm 파일에 추가했습니다. (ex. 저장 버튼 클릭 시 처리 과정 등) 


### 작업 내역
- [x] 상품 등록, 상품 수정 폼 미입력 정보 확인 요청 방식 수정
- [x] ProductForm 파일 안으로 상품 등록, 상품 수정 공통 로직 추출

### 작업 후 기대 동작(스크린샷) 
<img src='https://github.com/timetam24/TypeScript/assets/135303974/9d9cf544-5de6-40a1-8e52-399f333aa845' width='50%'>


### PR 특이 사항


### 특이 사항 :
Issue Number #334

close: # 자기가 개발 전에 올린 이슈