### PR TITLE
[♻️ Refactor] 재사용되는 이미지 크롭 함수들 훅으로 분리

### DIFF
--- a/moamoa/src/Components/Product/ProductForm.jsx
+++ b/moamoa/src/Components/Product/ProductForm.jsx
@@ -34,7 +34,7 @@ export function ProductForm({
   onCancel,
   onSelectFile,
   setCroppedImageFor,
-  isOpen,
+  showImgModal,
   editMode,
   productId,
 }) {
@@ -103,7 +103,7 @@ export function ProductForm({
 
   return (
     <Form onSubmit={onSubmit}>
-      {isOpen && (
+      {showImgModal && (
         <ImageCropModal
           imageUrl={imgData.imageUrl}
           cropInit={imgData.crop}
@@ -238,7 +238,7 @@ ProductForm.propTypes = {
   onCancel: PropTypes.any.isRequired,
   onSelectFile: PropTypes.any.isRequired,
   setCroppedImageFor: PropTypes.any.isRequired,
-  isOpen: PropTypes.bool,
+  showImgModal: PropTypes.bool,
   editMode: PropTypes.bool,
   productId: PropTypes.string,
 };

--- a/moamoa/src/Hooks/Auth/useSignUp.jsx
+++ b/moamoa/src/Hooks/Auth/useSignUp.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import InputErrorMessagesReducer from './InputErrorMessagesReducer.jsx';
 import { updateInputState } from '../../Utils/updateInputState.jsx';
 import DefaultProfileImage from '../../Assets/images/profile-img.svg';
+import { useImage } from '../Common/useImage.jsx';
 
 const useSignUp = () => {
   const navigate = useNavigate();
@@ -25,42 +26,8 @@ const useSignUp = () => {
     },
   });
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [imgData, setImgData] = useState({
-    imageUrl: DefaultProfileImage,
-    croppedImageUrl: null,
-  });
-  const [prevImgData, setPrevImgData] = useState('');
-
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      setIsOpen(true);
-    }
-  };
-
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-    setImgData(newImage);
-    setIsOpen(false);
-  };
+  const { imgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(DefaultProfileImage);
 
   const { errorMessages } = InputErrorMessagesReducer();
 
@@ -126,7 +93,7 @@ const useSignUp = () => {
     onCancel,
     onSelectFile,
     setCroppedImageFor,
-    isOpen,
+    showImgModal,
   };
 };
 

--- a/moamoa/src/Hooks/Common/useImage.jsx
+++ b/moamoa/src/Hooks/Common/useImage.jsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export const useImage = (initialImg) => {
+  const [showImgModal, setShowImgModal] = useState(false);
+  const [imgData, setImgData] = useState({
+    imageUrl: initialImg,
+    croppedImageUrl: null,
+  });
+  const [prevImgData, setPrevImgData] = useState('');
+
+  const onSelectFile = (e) => {
+    e.preventDefault();
+    if (e.target.files && e.target.files.length > 0) {
+      const reader = new FileReader();
+      reader.addEventListener('load', () => {
+        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
+        setImgData((prevImage) => ({
+          ...prevImage,
+          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
+        }));
+      });
+      reader.readAsDataURL(e.target.files[0]);
+      setShowImgModal(true);
+    }
+  };
+
+  // 모달에서 닫기창 클릭 시 처리
+  const onCancel = () => {
+    setImgData((prevImage) => ({
+      ...prevImage,
+      imageUrl: prevImgData, // 이전 이미지로 설정
+    }));
+    setShowImgModal(false);
+  };
+
+  // 모달에서 크롭한 이미지 저장
+  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
+    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
+    setImgData(newImage);
+    setShowImgModal(false);
+  };
+
+  return { imgData, setImgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor };
+};

--- a/moamoa/src/Hooks/Product/useProductData.jsx
+++ b/moamoa/src/Hooks/Product/useProductData.jsx
@@ -8,10 +8,6 @@ export const useProductData = (initialState) => {
   const [location, setLocation] = useState(initialState.location);
   const [description, setDescription] = useState(initialState.description);
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [imgData, setImgData] = useState(initialState.image);
-  const [prevImgData, setPrevImgData] = useState('');
-
   const [showModal, setShowModal] = useState(false);
   const [editMode, setEditMode] = useState(false);
 
@@ -28,12 +24,6 @@ export const useProductData = (initialState) => {
     setLocation,
     description,
     setDescription,
-    isOpen,
-    setIsOpen,
-    imgData,
-    setImgData,
-    prevImgData,
-    setPrevImgData,
     showModal,
     setShowModal,
     editMode,

--- a/moamoa/src/Pages/Auth/SignUp.jsx
+++ b/moamoa/src/Pages/Auth/SignUp.jsx
@@ -27,7 +27,6 @@ const SignUp = () => {
     pageTransition,
     userTypeErrorMessage,
     signUpFailMessage,
-    isOpen,
     updateUserData,
     updateUserType,
     clickNextButton,
@@ -36,6 +35,7 @@ const SignUp = () => {
     onCancel,
     onSelectFile,
     setCroppedImageFor,
+    showImgModal,
   } = useSignUp();
 
   const {
@@ -67,7 +67,7 @@ const SignUp = () => {
       <h1 className='a11y-hidden'>이메일로 회원가입 및 프로필 설정</h1>
       {pageTransition ? (
         <Container>
-          {isOpen && (
+          {showImgModal && (
             <ImageCropModal
               imageUrl={imgData.imageUrl}
               cropInit={imgData.crop}

--- a/moamoa/src/Pages/Post/EditPost.jsx
+++ b/moamoa/src/Pages/Post/EditPost.jsx
@@ -25,6 +25,7 @@ import xButton from '../../Assets/icons/x.svg';
 
 import { getPostDetail, editPost } from '../../API/Post/PostAPI';
 // import { uploadImage } from '../../API/Image/ImageAPI';
+import { useImage } from '../../Hooks/Common/useImage';
 import ImageCropModal from '../../Components/Modal/ImageCropModal';
 
 import {
@@ -49,13 +50,8 @@ export default function EditPost() {
   const [content, setContent] = useState('');
   // const [image, setImage] = useState('');
 
-  // 이미지 크롭 관련 상태 변수
-  const [isOpen, setIsOpen] = useState(false);
-  const [imgData, setImgData] = useState({
-    imageUrl: '',
-    croppedImageUrl: null,
-  });
-  const [prevImgData, setPrevImgData] = useState('');
+  const { imgData, setImgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(null);
 
   const getInitPostInfo = async () => {
     const postInfo = await getPostDetail(postId);
@@ -93,39 +89,6 @@ export default function EditPost() {
 
   //   setImage(imageUrl);
   // };
-
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      // 이미지 크롭 모달 띄우기
-      setIsOpen(true);
-    }
-  };
-
-  // 모달에서 닫기창 클릭 시 처리
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  // 모달에서 크롭한 이미지 저장
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-    setImgData(newImage);
-    setIsOpen(false);
-  };
 
   //textarea 높이 설정
   const adjustTextareaHeight = (event) => {
@@ -189,7 +152,7 @@ export default function EditPost() {
         <Gobackbtn />
         <ButtonSubmit buttonText='저장' onClickHandler={submitEdit} disabled={isButtonDisabled} />
       </HeaderContainer>
-      {isOpen && (
+      {showImgModal && (
         <ImageCropModal
           imageUrl={imgData.imageUrl}
           cropInit={imgData.crop}

--- a/moamoa/src/Pages/Post/UploadPost.jsx
+++ b/moamoa/src/Pages/Post/UploadPost.jsx
@@ -23,6 +23,7 @@ import { uploadPost } from '../../API/Post/PostAPI';
 // import { uploadImage } from '../../API/Image/ImageAPI';
 
 import { getMyProfileData } from '../../API/Profile/ProfileAPI';
+import { useImage } from '../../Hooks/Common/useImage';
 import ImageCropModal from '../../Components/Modal/ImageCropModal';
 
 import {
@@ -44,13 +45,8 @@ export default function AddPost() {
   const [userImage, setUserImage] = useState('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
-  // 이미지 크롭 관련 상태 변수
-  const [isOpen, setIsOpen] = useState(false);
-  const [imgData, setImgData] = useState({
-    imageUrl: '',
-    croppedImageUrl: null,
-  });
-  const [prevImgData, setPrevImgData] = useState('');
+  const { imgData, setImgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(null);
 
   const getUserImg = async () => {
     try {
@@ -80,39 +76,6 @@ export default function AddPost() {
   //   const imageUrl = `https://api.mandarin.weniv.co.kr/${response.data.filename}`;
   //   setPostImage(imageUrl);
   // };
-
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      // 이미지 크롭 모달 띄우기
-      setIsOpen(true);
-    }
-  };
-
-  // 모달에서 닫기창 클릭 시 처리
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  // 모달에서 크롭한 이미지 저장
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-    setImgData(newImage);
-    setIsOpen(false);
-  };
 
   //textarea 높이 설정
   const adjustTextareaHeight = (event) => {
@@ -172,7 +135,7 @@ export default function AddPost() {
         <Gobackbtn />
         <ButtonSubmit buttonText='업로드' onClickHandler={submitPost} disabled={isButtonDisabled} />
       </HeaderContainer>
-      {isOpen && (
+      {showImgModal && (
         <ImageCropModal
           imageUrl={imgData.imageUrl}
           cropInit={imgData.crop}

--- a/moamoa/src/Pages/Product/ProductAdd.jsx
+++ b/moamoa/src/Pages/Product/ProductAdd.jsx
@@ -4,6 +4,7 @@ import { useProductData } from '../../Hooks/Product/useProductData';
 import { Container } from '../../Components/Common/Container';
 import { HeaderSubmitProduct } from '../../Components/Common/Header/HeaderComponents';
 import DefaultImg from '../../Assets/images/img-product-default.png';
+import { useImage } from '../../Hooks/Common/useImage';
 
 const ProductAdd = () => {
   const initialState = {
@@ -13,10 +14,6 @@ const ProductAdd = () => {
     endDate: '',
     location: '',
     description: '',
-    image: {
-      imageUrl: DefaultImg,
-      croppedImageUrl: null,
-    },
   };
 
   const {
@@ -32,12 +29,6 @@ const ProductAdd = () => {
     setLocation,
     description,
     setDescription,
-    isOpen,
-    setIsOpen,
-    imgData,
-    setImgData,
-    prevImgData,
-    setPrevImgData,
     showModal,
     setShowModal,
     editMode,
@@ -48,36 +39,8 @@ const ProductAdd = () => {
     setEditMode(false);
   }, []);
 
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-
-    setImgData(newImage);
-    setIsOpen(false);
-  };
-
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      setIsOpen(true);
-    }
-  };
+  const { imgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(DefaultImg);
 
   return (
     <>
@@ -98,7 +61,7 @@ const ProductAdd = () => {
           onCancel={onCancel}
           onSelectFile={onSelectFile}
           setCroppedImageFor={setCroppedImageFor}
-          isOpen={isOpen}
+          showImgModal={showImgModal}
           editMode={editMode}
         />
       </Container>

--- a/moamoa/src/Pages/Product/ProductEdit.jsx
+++ b/moamoa/src/Pages/Product/ProductEdit.jsx
@@ -6,6 +6,7 @@ import { getProductDetail } from '../../API/Product/ProductAPI';
 import { Container } from '../../Components/Common/Container';
 import DefaultImg from '../../Assets/images/img-product-default.png';
 import { HeaderSubmitProduct } from '../../Components/Common/Header/HeaderComponents';
+import { useImage } from '../../Hooks/Common/useImage';
 
 const ProductEdit = () => {
   const params = useParams();
@@ -18,10 +19,6 @@ const ProductEdit = () => {
     endDate: '',
     location: '',
     description: '',
-    image: {
-      imageUrl: DefaultImg,
-      croppedImageUrl: null,
-    },
   };
 
   const {
@@ -37,49 +34,14 @@ const ProductEdit = () => {
     setLocation,
     description,
     setDescription,
-    isOpen,
-    setIsOpen,
-    imgData,
-    setImgData,
-    prevImgData,
-    setPrevImgData,
     showModal,
     setShowModal,
     editMode,
     setEditMode,
   } = useProductData(initialState);
 
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-
-    setImgData(newImage);
-
-    setIsOpen(false);
-  };
-
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      setIsOpen(true);
-    }
-  };
+  const { imgData, setImgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(DefaultImg);
 
   const getProductData = (data) => {
     const period = data.product.price.toString();
@@ -120,7 +82,7 @@ const ProductEdit = () => {
         onCancel={onCancel}
         onSelectFile={onSelectFile}
         setCroppedImageFor={setCroppedImageFor}
-        isOpen={isOpen}
+        showImgModal={showImgModal}
         editMode={editMode}
         productId={productId}
       />

--- a/moamoa/src/Pages/Profile/EditProfile.jsx
+++ b/moamoa/src/Pages/Profile/EditProfile.jsx
@@ -23,6 +23,7 @@ import { HeaderContainer, HiddenH1 } from '../Post/UploadEditPostStyle';
 
 import { getMyProfileData } from '../../API/Profile/ProfileAPI';
 
+import { useImage } from '../../Hooks/Common/useImage';
 import ImageCropModal from '../../Components/Modal/ImageCropModal';
 
 function EditProfile() {
@@ -35,13 +36,8 @@ function EditProfile() {
   // const [imgSrc, setImgSrc] = useState('');
   const [intro, setIntro] = useState('');
 
-  // 이미지 크롭 관련 상태 변수
-  const [isOpen, setIsOpen] = useState(false);
-  const [imgData, setImgData] = useState({
-    imageUrl: '',
-    croppedImageUrl: null,
-  });
-  const [prevImgData, setPrevImgData] = useState('');
+  const { imgData, setImgData, showImgModal, onSelectFile, onCancel, setCroppedImageFor } =
+    useImage(null);
 
   // const [errorMessage, setErrorMessage] = useState('');
   const [accountError, setAccountError] = useState('');
@@ -184,39 +180,6 @@ function EditProfile() {
   //   uploadImage(imageFile);
   // };
 
-  const onSelectFile = (e) => {
-    e.preventDefault();
-    if (e.target.files && e.target.files.length > 0) {
-      const reader = new FileReader();
-      reader.addEventListener('load', () => {
-        setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
-        setImgData((prevImage) => ({
-          ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
-        }));
-      });
-      reader.readAsDataURL(e.target.files[0]);
-      // 이미지 크롭 모달 띄우기
-      setIsOpen(true);
-    }
-  };
-
-  // 모달에서 닫기창 클릭 시 처리
-  const onCancel = () => {
-    setImgData((prevImage) => ({
-      ...prevImage,
-      imageUrl: prevImgData, // 이전 이미지로 설정
-    }));
-    setIsOpen(false);
-  };
-
-  // 모달에서 크롭한 이미지 저장
-  const setCroppedImageFor = (crop, zoom, croppedImageUrl) => {
-    const newImage = { ...imgData, croppedImageUrl, crop, zoom };
-    setImgData(newImage);
-    setIsOpen(false);
-  };
-
   const submitEdit = (e) => {
     e.preventDefault();
 
@@ -272,7 +235,7 @@ function EditProfile() {
         <Gobackbtn />
         <ButtonSubmit buttonText='저장' onClickHandler={submitEdit} disabled={isButtonDisabled} />
       </HeaderContainer>
-      {isOpen && (
+      {showImgModal && (
         <ImageCropModal
           imageUrl={imgData.imageUrl}
           cropInit={imgData.crop}


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
이미지 크롭을 위해 사용되고 있는 아래 함수들이 각 컴포넌트(프로필 설정 & 수정, 상품 등록 & 수정, 게시글 등록 & 수정)에서 재사용되고 있습니다. 

1. onSelectFile
2. onCancel
3. setCroppedImageFor

별도의 훅 파일로 분리하여 컴포넌트의 복잡성을 줄였습니다.


### 작업 내역
- [x] 이미지 크롭 함수들 훅 파일로 분리 (파일명: useImage.jsx / 파일위치: Hooks-Common 폴더 안)
- [x] 각 컴포넌트에서 useImage 훅 호출하여 사용

### 작업 후 기대 동작(스크린샷) 


### PR 특이 사항


### 특이 사항 :
Issue Number #344

close: # 자기가 개발 전에 올린 이슈