### PR TITLE
[♻️ Refactor]유저 검색 페이지 렌더링 시 포커스

### DIFF
--- a/moamoa/src/Components/Common/Header/HeaderComponents.jsx
+++ b/moamoa/src/Components/Common/Header/HeaderComponents.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Gobackbtn from '../GoBackbtn';
@@ -95,6 +95,10 @@ export function HeaderSearch({ setSearchText }) {
   HeaderSearch.propTypes = {
     setSearchText: PropTypes.func,
   };
+  const inputFocus = useRef();
+  useEffect(() => {
+    inputFocus.current.focus();
+  });
   return (
     <HeaderSearchContainer>
       <Gobackbtn />
@@ -102,6 +106,7 @@ export function HeaderSearch({ setSearchText }) {
         type='search'
         placeholder='아이디를 입력하세요'
         onChange={(e) => setSearchText(e.target.value)}
+        ref={inputFocus}
       />
     </HeaderSearchContainer>
   );


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
유저 검색 페이지로 이동했을 때 포커스가 인풋창으로 되어있지 않아 사용자 경험이 좋지 않을 것으로 판단했습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
Components/Common/Header/HeaderComponents.jsx의 HeaderSearch 컴포넌트에
useRef를 이용하여 구현했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
설정 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/f04a6a89-40a0-4e56-89e1-5910c40b06f2)
설정 후 
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/06d68b54-ea1f-4a25-a598-d23ffe88f58c)


### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #346 

close: # #346 
