### PR TITLE
 [♻️ Refactor]축제&체험 4개씩 렌더링,기한이 지난 축제&체험 필터링

### DIFF
--- a/moamoa/src/API/Product/ProductAPI.jsx
+++ b/moamoa/src/API/Product/ProductAPI.jsx
@@ -78,6 +78,6 @@ export const editProduct = async (productId, productData) => {
 };
 // 축제&체험 리스트
 export async function ProductListAPI() {
-  const response = await authInstance.get('product/?limit=284&skip=0');
+  const response = await authInstance.get(`product/?limit=400`);
   return response.data.product;
 }

--- a/moamoa/src/Components/Product/ProductOutput.jsx
+++ b/moamoa/src/Components/Product/ProductOutput.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { ProductAtom } from '../../Recoil/ProductAtom';
 
@@ -6,21 +6,42 @@ import { Link } from 'react-router-dom';
 import { ProductListImgBox } from '../../Components/Common/ProductImgBox';
 import TopNavigation from '../../Components/Product/TopNavigation';
 import { filterActive } from './filterActive';
-import { formatEventStartDate } from './formatEventDate';
-import { formatEventEndDate } from './formatEventDate';
-import { semanticStartDate } from './formatEventDate';
-import { semanticEventEndDate } from './formatEventDate';
+import {
+  formatEventStartDate,
+  formatEventEndDate,
+  semanticStartDate,
+  semanticEventEndDate,
+} from './formatEventDate';
 import { ProductContainer, ProductBox } from './ProductStyle';
 
 export default function ProductBundle() {
   const product = useRecoilValue(ProductAtom);
   const filteredProducts = product.filter(filterActive);
 
+  const [nextPage, setNextPage] = useState(4);
+  useEffect(() => {
+    function handleScroll() {
+      const scrollPosition = window.innerHeight + window.scrollY;
+
+      const documentHeight = document.documentElement.scrollHeight;
+
+      if (scrollPosition === documentHeight) {
+        setNextPage((prev) => prev + 4);
+      }
+      console.log(nextPage);
+    }
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
   return (
     <>
       <TopNavigation />
       <ProductContainer>
-        {filteredProducts.map((item, index) => (
+        {filteredProducts.slice(0, nextPage).map((item, index) => (
           <ProductBox key={index}>
             <Link to={`/product/detail/${item._id}`} key={index}>
               <ProductListImgBox src={item.itemImage} />

--- a/moamoa/src/Components/Product/filterActive.js
+++ b/moamoa/src/Components/Product/filterActive.js
@@ -1,18 +1,28 @@
 import { useRecoilState } from 'recoil';
 import { festivalActiveState, experienceActiveState } from '../../Recoil/ProductTypeStateAtom';
 
+import { getTodayDate, semanticEventEndDate } from './formatEventDate';
 export function filterActive(item) {
+  const todayDate = new Date(getTodayDate());
+
+  const expEndDate = new Date(semanticEventEndDate(item.price.toString()));
+
   const [festivalActive, experienceActive] = useRecoilState(
     festivalActiveState,
     experienceActiveState,
   );
 
   if (festivalActive && item.itemName.includes('[f]')) {
+    if (todayDate > expEndDate) {
+      return false;
+    }
     return true;
   }
 
   if (!festivalActive && experienceActive && item.itemName.includes('[e]')) {
+    if (todayDate > expEndDate) {
+      return false;
+    }
     return true;
   }
-  return false;
 }

--- a/moamoa/src/Components/Product/formatEventDate.js
+++ b/moamoa/src/Components/Product/formatEventDate.js
@@ -26,3 +26,12 @@ export function semanticEventEndDate(dateString) {
 
   return `${endYear}-${endMonth}-${endDay}`;
 }
+
+export function getTodayDate() {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
축제&체험의 수가 많아지면 초기 렌더링이 늦어질 것으로 생각되었습니다.
축제&체험의 기한이 지났지만 데이터가 남아있었습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
렌더링
[nextPage,setNextPage] useState 에 초기값 4를 넣고 스크롤이 바닥에 닿으면
setNextPage에 이전 값 + 4를 넣었습니다.

기한 지난 축제&체험
오늘의 날짜를 담은 todayDate와 축제 기한의 마지막 날인 expEndDate를 비교하여 지났다면 filteredProducts 변수에 담기지 않게 하였습니다.




### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
기한 지난 축제 & 체험 수정 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/1a5824f6-a5d3-41d5-aa1d-3ec289e6e7c6)
기한 지난 축제 & 체험 수정 후
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/cd08d3fa-13e0-42da-8c5c-8b0e865bb372)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
기한이 지난 축제&체험을 볼 수 있는 공간이 필요한지 의견 주시면 감사하겠습니다.



### 특이 사항 : #328 #348 
Issue Number

close: # 자기가 개발 전에 올린 이슈
