### PR TITLE
[ 🔧 Fix ] 로그인 시 이전 사용자 데이터가 남는 오류

### DIFF
--- a/src/Components/Common/Header/HeaderKebab.jsx
+++ b/src/Components/Common/Header/HeaderKebab.jsx
@@ -40,12 +40,15 @@ export default function HeaderKebab() {
     closeConfirmLogoutModal();
 
     setToken('');
+    console.log(localStorage);
     localStorage.removeItem('token');
+    localStorage.removeItem('recoil-persist');
     setIsLoginState(false);
     setAccountName('');
     setUserName('');
     setPostsData(null);
     navigate('/user/login');
+    console.log(localStorage);
   };
 
   //모달 창 닫기

--- a/src/Components/Common/Header/HeaderKebab.jsx
+++ b/src/Components/Common/Header/HeaderKebab.jsx
@@ -38,9 +38,7 @@ export default function HeaderKebab() {
   const logout = () => {
     // 로그아웃 로직 처리
     closeConfirmLogoutModal();
-
     setToken('');
-    console.log(localStorage);
     localStorage.removeItem('token');
     localStorage.removeItem('recoil-persist');
     setIsLoginState(false);
@@ -48,7 +46,6 @@ export default function HeaderKebab() {
     setUserName('');
     setPostsData(null);
     navigate('/user/login');
-    console.log(localStorage);
   };
 
   //모달 창 닫기


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
로그아웃 후 다른 계정으로 로그인 했을 때 이전 사용자가 팔로잉 하고 있는 유저의 게시글이 홈 피드에 나타나는 오류가 있었습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
로그아웃 시 로컬 스토리지에 저장된 토큰만 지우는 것이 아니라 recoil-persist도 초기화 해 문제를 해결했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![2024-01-202 51 50-ezgif com-video-to-gif-converter](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/90a5c32e-0f1b-4c6b-a0e8-829da2ddd2ba)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
home 화면에서 처음에 검색하기 화면이 나오는 문제가 있어, 해결하도록 하겠습니다.

close: #282 