### PR TITLE
[♻️ Refactor ]스플래시 페이지 태블릿 크기 반응형 구현

### DIFF
--- a/src/Components/Splash/LoginModal.jsx
+++ b/src/Components/Splash/LoginModal.jsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import SplashLoginBtn from './SplashLoginBtn';
 import { Link } from 'react-router-dom';
-import { Modal } from './SplashStyle';
+import { LoginH1, Modal } from './SplashStyle';
+import { useRecoilState } from 'recoil';
+import { modalActiveState } from '../../Recoil/modalActiveState ';
 
 export default function LoginModal() {
-  const [modalActive, setModalActive] = useState(false);
+  const [modalActive, setModalActive] = useRecoilState(modalActiveState);
   useEffect(() => {
     const modalTimeout = setTimeout(() => {
       setModalActive(true);
@@ -15,6 +17,7 @@ export default function LoginModal() {
   return (
     <div>
       <Modal visible={modalActive ? true : false}>
+        <LoginH1>로그인</LoginH1>
         <SplashLoginBtn></SplashLoginBtn>
         <p className='joinGuide'>아직 회원이 아니신가요?</p>
         <Link to='/user/signUp'>이메일로 회원가입</Link>

--- a/src/Components/Splash/SplashLogo.jsx
+++ b/src/Components/Splash/SplashLogo.jsx
@@ -3,34 +3,37 @@ import Logo from '../../Assets/images/Logo.png';
 import fireworks from '../../Assets/images/fireworks.svg';
 import Festival from '../../Assets/images/Festival.svg';
 import { SVGgroup, AnimationFireworks } from './SplashStyle';
+import { useRecoilValue } from 'recoil';
+import { modalActiveState } from '../../Recoil/modalActiveState ';
 export default function SplashLogo() {
+  const modalActive = useRecoilValue(modalActiveState);
   return (
     <div>
-      <SVGgroup>
+      <SVGgroup visible={modalActive}>
         <div>
           <img src={Festival} className='blinkFestival' alt='' />
           <img src={fireworks} className='blinkfireworks' alt='' />
         </div>
         <img src={Logo} alt='모아모아 로고' />
         <p className='logotext'>내 손 안의 안의 모든 축제!</p>
+        <AnimationFireworks>
+          <div className='firework-1'></div>
+          <div className='firework-2'></div>
+          <div className='firework-3'></div>
+          <div className='firework-4'></div>
+          <div className='firework-5'></div>
+          <div className='firework-6'></div>
+          <div className='firework-7'></div>
+          <div className='firework-8'></div>
+          <div className='firework-9'></div>
+          <div className='firework-10'></div>
+          <div className='firework-11'></div>
+          <div className='firework-12'></div>
+          <div className='firework-13'></div>
+          <div className='firework-14'></div>
+          <div className='firework-15'></div>
+        </AnimationFireworks>
       </SVGgroup>
-      <AnimationFireworks>
-        <div className='firework-1'></div>
-        <div className='firework-2'></div>
-        <div className='firework-3'></div>
-        <div className='firework-4'></div>
-        <div className='firework-5'></div>
-        <div className='firework-6'></div>
-        <div className='firework-7'></div>
-        <div className='firework-8'></div>
-        <div className='firework-9'></div>
-        <div className='firework-10'></div>
-        <div className='firework-11'></div>
-        <div className='firework-12'></div>
-        <div className='firework-13'></div>
-        <div className='firework-14'></div>
-        <div className='firework-15'></div>
-      </AnimationFireworks>
     </div>
   );
 }

--- a/src/Components/Splash/SplashStyle.js
+++ b/src/Components/Splash/SplashStyle.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import { TempLoginButton } from './SplashLoginBtn';
 
 export const StyledButton = styled(TempLoginButton)`
-  margin: 0 auto;
   width: 322px;
   height: 44px;
   border-radius: 44px;
@@ -45,9 +44,38 @@ export const Modal = styled.div.withConfig({
   a:hover {
     font-size: 13px;
   }
+  @media (min-width: 768px) {
+    position: fixed;
+    height: 740px;
+    top: 0px;
+
+    right: ${(props) => (props.visible === true ? '-195px' : '-600px')};
+    padding: 100px 0 20px;
+    a {
+      padding-top: 0;
+    }
+    .joinGuide {
+      padding-top: 0;
+      margin-block: 50px 20px;
+      color: var(--buttonDisable);
+      font-size: 12px;
+    }
+  }
+`;
+export const LoginH1 = styled.h1`
+  @media (max-width: 767px) {
+    display: none;
+  }
+  @media (min-width: 768px) {
+    font-size: 24px;
+    margin: 0 auto;
+    padding-bottom: 50px;
+  }
 `;
 
-export const SVGgroup = styled.div`
+export const SVGgroup = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== 'visible',
+})`
   display: flex;
   justify-content: space-between;
   flex-direction: column;
@@ -67,7 +95,16 @@ export const SVGgroup = styled.div`
   img {
     width: 202px;
   }
+  @media (min-width: 768px) {
+    position: absolute;
+    top: 20%;
+    transition: 0.5s ease;
+    left: ${(props) => (props.visible === true ? '25%' : '50%')};
+    display: flex;
+    transform: translate(-50%, -50%);
+  }
 `;
+
 export const AnimationFireworks = styled.div`
   [class^='firework-'] {
     z-index: 100;
@@ -79,7 +116,7 @@ export const AnimationFireworks = styled.div`
   .firework-1 {
     animation: firework-sm 1.2s both infinite;
     animation-delay: 1.1s;
-    top: 19%;
+    top: 15%;
     left: 15%;
   }
   .firework-2 {
@@ -153,6 +190,57 @@ export const AnimationFireworks = styled.div`
     animation-delay: 0.8s;
     top: 30%;
     left: 58%;
+  }
+  @media (min-width: 768px) {
+    .firework-1 {
+      top: 45%;
+      left: -19%;
+    }
+    .firework-2 {
+      top: 40%;
+      left: 9%;
+    }
+    .firework-3 {
+      top: 75%;
+    }
+    .firework-4 {
+      top: 194%;
+    }
+    .firework-5 {
+      top: 95%;
+      left: 85%;
+    }
+    .firework-6 {
+      top: 120%;
+      left: 130%;
+    }
+    .firework-7 {
+      top: 57%;
+      left: 130%;
+    }
+    .firework-8 {
+      top: 10%;
+      left: 130%;
+    }
+    .firework-9 {
+      top: 42%;
+      left: 110%;
+    }
+    .firework-10 {
+      top: 24%;
+      left: 100%;
+    }
+    .firework-11 {
+      top: 126%;
+      left: 30%;
+    }
+    .firework-12 {
+      top: 166%;
+      left: 110%;
+    }
+    .firework-13 {
+      top: 160%;
+    }
   }
 
   @keyframes firework-sm {

--- a/src/Pages/Splash/Landing.jsx
+++ b/src/Pages/Splash/Landing.jsx
@@ -2,13 +2,17 @@ import React from 'react';
 import LoginModal from '../../Components/Splash/LoginModal';
 import SplashLogo from '../../Components/Splash/SplashLogo';
 import { MoaMoaBox, Copyright } from './SplashStyle';
+import { modalActiveState } from '../../Recoil/modalActiveState ';
+import { useRecoilValue } from 'recoil';
 
 export default function Landing() {
+  const modalActive = useRecoilValue(modalActiveState);
+
   return (
     <MoaMoaBox>
       <SplashLogo />
       <LoginModal />
-      <Copyright>@copyright moamoa corp</Copyright>
+      <Copyright visible={modalActive}>@copyright moamoa corp</Copyright>
     </MoaMoaBox>
   );
 }

--- a/src/Pages/Splash/SplashStyle.js
+++ b/src/Pages/Splash/SplashStyle.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-export const MoaMoaBox = styled.div`
+export const MoaMoaBox = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== 'visible',
+})`
   background-color: #2e2c39;
   display: flex;
   flex-direction: column;
@@ -16,9 +18,29 @@ export const MoaMoaBox = styled.div`
   }
   overflow: hidden;
   position: relative;
+  @media (min-width: 768px) {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+
+    height: 740px;
+    display: flex;
+    width: 780px;
+    transform: translate(-50%, -50%);
+    overflow: hidden;
+    border-radius: 10px;
+  }
 `;
-export const Copyright = styled.p`
+export const Copyright = styled.div.withConfig({
+  shouldForwardProp: (prop) => prop !== 'visible',
+})`
   margin-top: 370px;
   color: #ffffff;
   font-size: 14px;
+  @media (min-width: 768px) {
+    position: absolute;
+    top: 30%;
+    transition: 0.5s ease;
+    left: ${(props) => (props.visible === true ? '14%' : '40%')};
+  }
 `;

--- a/src/Recoil/modalActiveState .jsx
+++ b/src/Recoil/modalActiveState .jsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const modalActiveState = atom({
+  key: 'modalActiveState',
+  default: false,
+});


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
로그인 모달이 오른쪽에서 왼쪽으로 애니메이션 될 때 
로고와 copyright가 왼쪽으로 같이 밀리는 애니메이션을 위해 
modalActiveState를 recoil로 상태를 공유하여 처리했습니다.

768px부터 동작하도록 만들었습니다.


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
모바일
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/91aa04e8-eccb-4cb7-b961-bf055b3b2985)

태블릿
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/3077de79-25ea-471f-84f5-9665ff11e838)



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #360 

close: # 자기가 개발 전에 올린 이슈
