### PR TITLE
 [♻️ Refactor / 🌈 Style] 축제 상세 태블릿 ui 구현, 게시글 상세 nav bar 추가

### DIFF
--- a/src/Components/Comment/Comment.jsx
+++ b/src/Components/Comment/Comment.jsx
@@ -89,12 +89,12 @@ const AddCommentCont = styled.div`
     width: 100%;
     height: 6rem;
     border-top: 1px solid #dbdbdb;
-    margin: auto;
-    padding: 0 2rem;
+    margin: 0 0 0 60px;
     position: fixed;
     bottom: 0;
     left: 50%;
     transform: translate(-50%);
+    background-color: #fff;
   }
 `
 
@@ -103,7 +103,7 @@ const AddComment = styled.form`
   width: 100%;
   max-width: 39rem;
   height: 6rem;
-  background-color: white;
+  background-color: #fff;
   border-top: 1px solid #dbdbdb;
   margin: auto;
   padding: 0 2rem;

--- a/src/Components/Common/Header/HeaderKebab.jsx
+++ b/src/Components/Common/Header/HeaderKebab.jsx
@@ -87,7 +87,7 @@ export default function HeaderKebab() {
 const HeaderContainer = styled.header`
   display: flex;
   margin: 0 auto;
-  z-index: 100;
+  z-index: 3;
   height: 48px;
   width: 390px;
 

--- a/src/Components/Product/AskBtn.jsx
+++ b/src/Components/Product/AskBtn.jsx
@@ -48,13 +48,13 @@ const Eidt = styled.button`
   width: 10rem;
   height: 2.8rem;
   border-radius: 2rem;
-  border: 2px solid #dbdbdb;
-  color: #767676;
+  border: 1px solid #767676;
+  color: #2E2C39;
   font-size: 1.2rem;
   &:hover {
     cursor: pointer;
-    background-color: #dbdbdb;
-    color: #000;
+    background-color: var(--buttonActive);
+    color: #fff;
   }
   margin-left: 1rem;
 `;

--- a/src/Components/Product/FestaMap.jsx
+++ b/src/Components/Product/FestaMap.jsx
@@ -87,7 +87,7 @@ geocoder.addressSearch(festaName, callback);
       { showMap ?
       <Map>
         <FestivalDesc>{festaName}</FestivalDesc>
-        <div id="map" style={{width:'358px',height:'300px'}}></div>
+        <div id="map" style={{width:'100%',height:'300px'}}></div>
       </Map> : 
       <NotMap>
         <MonoImg src={monomoa} alt="모아모아 캐릭터" />

--- a/src/Components/Product/ProductContents.jsx
+++ b/src/Components/Product/ProductContents.jsx
@@ -40,9 +40,17 @@ const FestivalImg = styled.img`
   height: 27rem;
   aspect-ratio: 39/27;
   object-fit: cover;
+  @media (min-width: 768px) {
+    width: 480px;
+    height: 290px;
+    border-radius: 10px;
+  }
 `;
 const InfoContainer = styled.div`
   padding: 0 1.6rem;
+  @media (min-width: 768px) {
+    padding: 0;
+  }
 `;
 const FestivalTitle = styled.h3`
   font-size: 1.8rem;

--- a/src/GlobalStyle.jsx
+++ b/src/GlobalStyle.jsx
@@ -29,7 +29,6 @@ body{
 
 	@media (min-width: 768px) {
     background-color:#fff;
-		margin-left: 120px;
   }
 }
 a{

--- a/src/GlobalStyle.jsx
+++ b/src/GlobalStyle.jsx
@@ -29,6 +29,7 @@ body{
 
 	@media (min-width: 768px) {
     background-color:#fff;
+		margin-left: 120px;
   }
 }
 a{

--- a/src/Pages/Home/HomeStyle.jsx
+++ b/src/Pages/Home/HomeStyle.jsx
@@ -18,6 +18,7 @@ export const PostBg = styled.div`
   background-color: #fff;
   @media (min-width: 768px) {
     max-width: 480px;
+		padding-left: 120px;
   }
 `;
 
@@ -38,7 +39,8 @@ export const HomeCont = styled.div`
   background-position: 50% 35%;
   margin-top: 180px;
   @media (min-width: 768px) {
-    background-position: 50% 35%;
+    background-position: 58.3% 35%;
+		padding-left: 120px;
   }
 `;
 

--- a/src/Pages/Home/HomeStyle.jsx
+++ b/src/Pages/Home/HomeStyle.jsx
@@ -18,7 +18,6 @@ export const PostBg = styled.div`
   background-color: #fff;
   @media (min-width: 768px) {
     max-width: 480px;
-    padding-left: 120px;
   }
 `;
 
@@ -39,8 +38,7 @@ export const HomeCont = styled.div`
   background-position: 50% 35%;
   margin-top: 180px;
   @media (min-width: 768px) {
-    padding-left: 120px;
-    background-position: 58.3% 35%;
+    background-position: 50% 35%;
   }
 `;
 

--- a/src/Pages/Post/PostDetail.jsx
+++ b/src/Pages/Post/PostDetail.jsx
@@ -23,10 +23,10 @@ export default function ProductDetail() {
   },[])
   return (
     <>
+      <HeaderKebab />
       <NavbarCont>
         <Footer/>
       </NavbarCont>
-      <HeaderKebab />
       {post && (
         <PostContainer>
           <PostItemContainer>

--- a/src/Pages/Post/PostDetail.jsx
+++ b/src/Pages/Post/PostDetail.jsx
@@ -3,8 +3,9 @@ import { useParams } from 'react-router-dom';
 import PostItem from '../../Components/Post/PostItem';
 import Comment from '../../Components/Comment/Comment';
 import HeaderKebab from '../../Components/Common/Header/HeaderKebab';
+import Footer from '../../Components/Common/Footer';
 import { getPostDetail } from '../../API/Post/PostAPI';
-import { PostContainer, PostItemContainer } from './PostDetailStyle'
+import { PostContainer, PostItemContainer, NavbarCont } from './PostDetailStyle'
 
 export default function ProductDetail() {
   const [post, setPost] = useState();
@@ -22,9 +23,12 @@ export default function ProductDetail() {
   },[])
   return (
     <>
+      <NavbarCont>
+        <Footer/>
+      </NavbarCont>
+      <HeaderKebab />
       {post && (
         <PostContainer>
-          <HeaderKebab />
           <PostItemContainer>
             <PostItem post={post} />
           </PostItemContainer>

--- a/src/Pages/Post/PostDetailStyle.jsx
+++ b/src/Pages/Post/PostDetailStyle.jsx
@@ -1,6 +1,13 @@
 import styled from 'styled-components';
 import commentBg from '../../Assets/icons/message-circle.svg';
 
+export const NavbarCont = styled.div`
+  display: none;
+  @media (min-width: 768px) {
+    display: block;
+  }
+`
+
 export const PostContainer = styled.div`
   width: 100%;
   height: 100%;

--- a/src/Pages/Post/PostDetailStyle.jsx
+++ b/src/Pages/Post/PostDetailStyle.jsx
@@ -19,7 +19,8 @@ export const PostContainer = styled.div`
     display: none;
   }
   @media (min-width: 768px) {
-    max-width: 480px;
+    max-width: 600px;
+    padding-left: 120px;
   }
 `;
 export const PostItemContainer = styled.div`

--- a/src/Pages/Product/ProductDetail.jsx
+++ b/src/Pages/Product/ProductDetail.jsx
@@ -38,9 +38,9 @@ export default function ProductDetail() {
 
   return (
     <>
+      <Header type='home' />
       {productData && productAuthorInfo && (
         <FestivalContainer>
-          <Header type='home' />
           <FestivalArticle>
             <Frofile>
               <ArticleUserProfile userProfileData={userProfileData} />

--- a/src/Pages/Product/ProductStyle.js
+++ b/src/Pages/Product/ProductStyle.js
@@ -10,13 +10,18 @@ export const FestivalContainer = styled.div`
   width: 100%;
   height: 100%;
   margin: auto;
-
   background-color: #ffffff;
   overflow: hidden;
+  @media (min-width: 768px) {
+    max-width: 480px;
+  }
 `;
 export const FestivalArticle = styled.article`
   margin-top: 4.8rem;
   margin-bottom: 7rem;
+  @media (min-width: 768px) {
+    margin-top: 120px;
+  }
 `;
 export const Frofile = styled.div`
   height: 4.2rem;
@@ -25,34 +30,4 @@ export const Frofile = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-`;
-
-export const FestivalImg = styled.img`
-  width: 39rem;
-  height: 27rem;
-  aspect-ratio: 39/27;
-  object-fit: cover;
-`;
-export const InfoContainer = styled.div`
-  padding: 0 1.6rem;
-`;
-export const FestivalTitle = styled.h3`
-  font-size: 1.8rem;
-  font-weight: bold;
-  padding: 1.6rem 1.8rem;
-`;
-
-export const FestivalInfo = styled.h4`
-  font-size: 1.4rem;
-  font-weight: bold;
-  padding: 1.6rem 1.8rem 0.6rem;
-  border-top: 1px solid #dbdbdb;
-`;
-
-export const FestivalDesc = styled.p`
-  font-size: 1.4rem;
-  padding: 0 1.8rem;
-  margin-bottom: 1.6rem;
-  line-height: 2rem;
-  color: #767676;
 `;

--- a/src/Pages/Product/ProductStyle.js
+++ b/src/Pages/Product/ProductStyle.js
@@ -14,6 +14,7 @@ export const FestivalContainer = styled.div`
   overflow: hidden;
   @media (min-width: 768px) {
     max-width: 480px;
+    padding-left: 120px;
   }
 `;
 export const FestivalArticle = styled.article`


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
축제 상세 태블릿 ui 구현, 게시글 상세 nav bar 추가  작업 진행했습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
1. nav bar 영역이 차지 하는 공간만큼 컨텐츠가 padding을 가지도록 수정했습니다.
3. 축제 상세페이지 이미지 및 지도 영역 사이즈 조정, 여백 조정으로 태블릿 ui 작업 완료했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
|                                                게시글 상세                                                 |          축제 및 행사 상세                 |
| :-----------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: |
| <img width="692" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/5c46f13b-6e53-4dc8-b624-ec071a8fe042"> | <img width="692" alt="image" src="https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/118328426/d2f39d3b-91ba-4b43-b4ab-6f2f3c473eba"> |



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
1. Header 영역 작업이 진행되면 페이지 상단 여백 다시 조정하도록 하겠습니다.
2. 데스크탑 ui 작업 진행을 위한 추가 컴포넌트 구현 작업 시작하겠습니다.



### 특이 사항 :
Issue Number

close: # 자기가 개발 전에 올린 이슈
