### PR TITLE
[🔧 Fix]로고 텍스트 오타 수정,회원가입과 같은 위치로 로고 위치 수정

### DIFF
--- a/src/Components/Splash/SplashLogo.jsx
+++ b/src/Components/Splash/SplashLogo.jsx
@@ -15,7 +15,7 @@ export default function SplashLogo() {
           <img src={fireworks} className='blinkfireworks' alt='' />
         </div>
         <img src={Logo} alt='모아모아 로고' />
-        <p className='logotext'>내 손 안의 안의 모든 축제!</p>
+        <p className='logotext'>내 손 안의 모든 축제! 모아모아</p>
         <AnimationFireworks>
           <div className='firework-1'></div>
           <div className='firework-2'></div>

--- a/src/Components/Splash/SplashStyle.js
+++ b/src/Components/Splash/SplashStyle.js
@@ -108,15 +108,26 @@ export const SVGgroup = styled.div.withConfig({
     width: 57px;
     height: 57px;
   }
+  .logotext {
+    color: #fff;
+    margin-top: 8px;
+    font-size: 15px;
+    letter-spacing: 1px;
+    font-weight: 300;
+  }
   img {
     width: 202px;
   }
   @media (min-width: 768px) {
+    .blinkFestival {
+      margin-top: 0px;
+    }
     width: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
     position: absolute;
+    top: 29%;
     left: ${(props) => (props.visible === true ? '-25%' : '0%')};
     transition: 0.5s ease;
   }

--- a/src/Pages/Splash/SplashStyle.js
+++ b/src/Pages/Splash/SplashStyle.js
@@ -11,11 +11,7 @@ export const MoaMoaBox = styled.div.withConfig({
   width: 390px;
   height: 100vh;
   margin: 0 auto;
-  p {
-    padding-top: 10px;
-    color: #ffffff;
-    font-size: 18px;
-  }
+
   overflow: hidden;
   position: relative;
   @media (min-width: 768px) {
@@ -38,7 +34,7 @@ export const Copyright = styled.div.withConfig({
   font-size: 14px;
   @media (min-width: 768px) {
     position: absolute;
-    margin-top: 600px;
+    bottom: 10%;
     transition: 0.5s ease;
     left: ${(props) => (props.visible === true ? '25%' : '50%')};
     transform: translateX(-50%);


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
회원가입의 로고 위치와 로고의 위치를 같게 맞추었습니다.
로고 텍스트의 오타를 수정하였습니다.
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/f354cd81-c4bc-46a3-86f9-fa0f79775c15)



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->




### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
이메일로 회원가입의 로고와 같은 위치로 수정하였습니다.
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/0d077755-2a4a-4c33-b059-5c295a9faec0)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
태블릿
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/ed7b8fe9-1135-4438-a0bc-aa8a681bb93f)
데스크톱
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/555e2f16-9f09-46ca-832e-4414ea64b2ab)

@Sooooyeon 수연님이 구현해주신 페이지가 제 환경에서는 태블릿 사이즈에서 로고가 잘려 나오고 있어서 같이 수정해보면 좋겠습니다!!


### 특이 사항 :
Issue Number #359 

close: # 자기가 개발 전에 올린 이슈
