### PR TITLE
[🔧 Fix] NavBar 높이 반응 로그아웃 버튼 고정,콘솔 prop 오류 제거

### DIFF
--- a/src/Components/Common/NavBar.jsx
+++ b/src/Components/Common/NavBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 import homeButton from '../../Assets/icons/icon-home.svg';
 import chatButton from '../../Assets/icons/icon-message.svg';
@@ -37,7 +38,6 @@ import {
   TabLabel,
   TabletLogOut,
 } from './NavBarStyle';
-
 export default function NavBar() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -45,6 +45,10 @@ export default function NavBar() {
   const [showConfirmLogoutModal, setShowConfirmLogoutModal] = useRecoilState(
     showConfirmLogoutModalState,
   );
+  TabButton.propTypes = {
+    hideOnMobile: PropTypes.bool,
+  };
+
   const tabs = [
     { name: 'home', label: '홈', path: '/home', icon: homeButton, fillIcon: homeButtonFill },
     {
@@ -149,8 +153,8 @@ export default function NavBar() {
         ))}
 
         <TabletLogOut onClick={handleKebabClick}>
-          <img src={logoutButton} alt='로그아웃' />
-          <TabLabel className='logout'>로그아웃</TabLabel>
+          <img src={logoutButton} className='logoutImg' alt='로그아웃' />
+          <TabLabel className='logoutText'>로그아웃</TabLabel>
         </TabletLogOut>
       </TabMenu>
       {showConfirmLogoutModal && (

--- a/src/Components/Common/NavBarStyle.js
+++ b/src/Components/Common/NavBarStyle.js
@@ -30,11 +30,11 @@ export const TabMenu = styled.div`
   }
 `;
 export const TabButton = styled.button.withConfig({
-  shouldForwardProp: (prop) => prop !== 'active',
+  shouldForwardProp: (prop) => prop !== 'active' && prop !== 'hideOnMobile',
 })`
   height: 60px;
   width: 100%;
-  padding-bottom:4px;
+  padding-bottom: 4px;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -57,7 +57,7 @@ export const TabButton = styled.button.withConfig({
   }
 
   &:hover {
-    background-color: #3B394A;
+    background-color: #3b394a;
   }
 `;
 export const TabBtnImg = styled.img`
@@ -92,10 +92,14 @@ export const TabletLogOut = styled.button`
     padding: 6px 0 2px 50px;
     gap: 7px;
     bottom: 80px;
-    .logout {
+    .logoutText {
       transform: translateX(-30%);
     }
   }
+  @media (max-height: 767px) {
+    position: static;
+  }
+
   @media (min-width: 1200px) {
     width: 100%;
     flex-direction: row;
@@ -106,8 +110,8 @@ export const TabletLogOut = styled.button`
     }
   }
   &:hover {
-    background-color: #3B394A;
-    color: #FFC700;
+    background-color: #3b394a;
+    color: #ffc700;
   }
 `;
 export const TabletLogo = styled.img`


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/812d8197-8db9-4262-a2fe-51fc5869bf06)

높이가 767px보다 작을 때 로그아웃 버튼이 다른 버튼의 영역을 침범하여 수정했습니다.

![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/711035df-2a35-41d1-9531-4beb2bbd3256)

커스텀 속성이 콘솔에서 오류가 일어나 수정했습니다.

### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
 @media (max-height: 767px) {
    position: static;
  }
으로 위치를 고정시켰습니다.

커스텀 속성은 shouldForwardProp 을 이용하여 전파를 막아 오류를 없앴습니다.

### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/a860b5d5-d746-4d36-8ba7-226455f8be28)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #359

close: # 자기가 개발 전에 올린 이슈
