### PR TITLE
[♻️ Refactor ]팔로우 페이지 반응형 ui 구현,시맨틱 태그로 변경

### DIFF
--- a/src/Components/Common/FollowStyle.jsx
+++ b/src/Components/Common/FollowStyle.jsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+export const FollowWrap = styled.li`
+  width: 358px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  padding: 8px 0 8px 16px;
+  Button {
+    font-size: 12px;
+    font-weight: bold;
+    margin-left: 80px;
+  }
+  @media (min-width: 768px) {
+    width: 480px;
+    margin-left: 120px;
+    padding: 0px 0px 16px 0px;
+  }
+  @media (min-width: 1200px) {
+    margin-left: -200px;
+  }
+`;
+export const UserPhotoWrap = styled.div`
+  border: 1px solid var(--DBDBDB, #dbdbdb);
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  overflow: hidden;
+  cursor: pointer;
+`;
+export const UserPhoto = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+export const UserInfo = styled.div`
+  margin-left: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+export const UserId = styled.h2`
+  font-size: 14px;
+`;
+export const UserText = styled.span`
+  color: #767676;
+  font-size: 12px;
+  width: 150px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/src/Components/Common/FollowUser.jsx
+++ b/src/Components/Common/FollowUser.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import Button from '../Common/Button';
-import PropTypes from 'prop-types'; // npm install prop-types 설치 필요
+import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
+
+import { FollowWrap, UserPhotoWrap, UserPhoto, UserInfo, UserId, UserText } from './FollowStyle';
 
 FollowUser.propTypes = {
   src: PropTypes.string.isRequired,
@@ -22,7 +23,7 @@ export default function FollowUser(props) {
     navigate(`/profile/${accountname}`);
   };
   return (
-    <div>
+    <>
       <FollowWrap>
         <UserPhotoWrap>
           <UserPhoto
@@ -45,51 +46,6 @@ export default function FollowUser(props) {
           onClickHandler={handleButtonClick}
         ></Button>
       </FollowWrap>
-    </div>
+    </>
   );
 }
-
-const FollowWrap = styled.div`
-  width: 358px;
-  height: 50px;
-
-  width: 100%;
-  display: flex;
-  align-items: center;
-  padding: 8px 0 8px 16px;
-  Button {
-    font-size: 12px;
-    font-weight: bold;
-    margin-left: 80px;
-  }
-`;
-const UserPhotoWrap = styled.div`
-  border: 1px solid var(--DBDBDB, #dbdbdb);
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  overflow: hidden;
-  cursor: pointer;
-`;
-const UserPhoto = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
-const UserInfo = styled.div`
-  margin-left: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-`;
-const UserId = styled.h2`
-  font-size: 14px;
-`;
-const UserText = styled.span`
-  color: #767676;
-  font-size: 12px;
-  width: 150px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;

--- a/src/Components/Common/FollowingUser.jsx
+++ b/src/Components/Common/FollowingUser.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import styled from 'styled-components';
 import Button from '../Common/Button';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
+import { FollowWrap, UserPhotoWrap, UserPhoto, UserInfo, UserId, UserText } from './FollowStyle';
 
 FollowUser.propTypes = {
   src: PropTypes.string.isRequired,
@@ -47,48 +47,3 @@ export default function FollowUser(props) {
     </div>
   );
 }
-
-const FollowWrap = styled.div`
-  width: 358px;
-  height: 50px;
-
-  width: 100%;
-  display: flex;
-  align-items: center;
-  padding: 8px 0 8px 16px;
-  Button {
-    font-size: 12px;
-    font-weight: bold;
-    margin-left: 80px;
-  }
-`;
-const UserPhotoWrap = styled.div`
-  border: 1px solid var(--DBDBDB, #dbdbdb);
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  overflow: hidden;
-  cursor: pointer;
-`;
-const UserPhoto = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-`;
-const UserInfo = styled.div`
-  margin-left: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-`;
-const UserId = styled.h2`
-  font-size: 14px;
-`;
-const UserText = styled.span`
-  color: #767676;
-  font-size: 12px;
-  width: 150px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;

--- a/src/Components/Common/Header/HeaderStyle.js
+++ b/src/Components/Common/Header/HeaderStyle.js
@@ -64,6 +64,9 @@ export const HeaderFollowContainer = styled.div`
   padding-left: 16px;
   box-sizing: border-box;
   margin-bottom: 8px;
+  @media (min-width: 768px) {
+    display: none;
+  }
 `;
 export const ChatUserName = styled.h2`
   font-weight: 500;

--- a/src/Components/Common/NavBarStyle.js
+++ b/src/Components/Common/NavBarStyle.js
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-export const TabMenu = styled.div`
+export const TabMenu = styled.nav`
   width: 390px;
   height: 60px;
   background-color: #2e2c39;
@@ -29,7 +29,7 @@ export const TabMenu = styled.div`
     align-items: center;
   }
 `;
-export const TabButton = styled.button.withConfig({
+export const TabButton = styled.a.withConfig({
   shouldForwardProp: (prop) => prop !== 'active' && prop !== 'hideOnMobile',
 })`
   height: 60px;

--- a/src/Components/Product/ProductStyle.js
+++ b/src/Components/Product/ProductStyle.js
@@ -25,7 +25,7 @@ export const ExperienceBtn = styled(Button).withConfig({
   border: ${({ onActive }) => (onActive ? 'none' : '1px solid var(--buttonDisable)')};
 `;
 
-export const ProductContainer = styled.div`
+export const ProductContainer = styled.ul`
   max-width: 100%;
 
   margin: 10px auto;
@@ -47,7 +47,7 @@ export const ProductContainer = styled.div`
     background-position: 0% 93%;
   }
 `;
-export const ProductBox = styled.div`
+export const ProductBox = styled.li`
   margin: 0 auto;
 
   .itemName {
@@ -64,7 +64,7 @@ export const ProductBox = styled.div`
   }
 `;
 
-export const Nav = styled.div`
+export const Nav = styled.nav`
   display: flex;
   padding: 10px;
   .btn {

--- a/src/Components/Search/SearchStyle.js
+++ b/src/Components/Search/SearchStyle.js
@@ -36,7 +36,7 @@ export const SkeletonContainer = styled.div`
   }
 `;
 
-export const SearchResultBox = styled.div`
+export const SearchResultBox = styled.li`
   height: 50px;
   width: 100%;
   display: flex;

--- a/src/Pages/Chat/ChatStyle.js
+++ b/src/Pages/Chat/ChatStyle.js
@@ -105,7 +105,7 @@ export const RemoveFile = styled.div`
   margin: 0px 10px;
 `;
 
-export const ChatListWrap = styled.div`
+export const ChatListWrap = styled.ul`
   padding: 16px;
   display: flex;
   flex-direction: column;
@@ -128,7 +128,7 @@ export const SearchImg = styled.img`
   object-fit: cover;
   border-radius: 50px;
 `;
-export const SearchWrap = styled.div`
+export const SearchWrap = styled.li`
   position: relative;
   height: 50px;
   display: flex;

--- a/src/Pages/Follow/FollowStyle.js
+++ b/src/Pages/Follow/FollowStyle.js
@@ -1,5 +1,9 @@
 import styled from 'styled-components';
 
-export const FollowingWrap = styled.div`
+export const FollowingWrap = styled.ul`
   margin-top: 48px;
+  @media (min-width: 768px) {
+    margin-top: 80px;
+    margin-inline: auto;
+  }
 `;

--- a/src/Pages/Search/SearchStyle.js
+++ b/src/Pages/Search/SearchStyle.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const SearchListWrap = styled.div`
+export const SearchListWrap = styled.ul`
   height: 100%;
   margin-top: 48px;
   padding: 16px;


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
팔로우 페이지의 스타일 컴포넌트 코드가 분리가 안되어 있었고, 시맨틱 태그들이 쓰이지 않은 곳이 있었습니다.




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
팔로우 페이지는 media query를 이용해 반응형 ui를 구현하였습니다.

팔로우 페이지의 의미없는 div 태그를 fragment로 변경
FollowerWrap의 태그를 div에서 ul로 변경하고 유저를 li로 변경
navBar의 태그를 div에서 nav로 변경하고 이동하는 버튼들의 태그를 a태그로 변경
축제 리스트의 Container의 태그를 div에서 ul, 축제들을 li로 변경
검색 페이지의 Container의 태그를 div에서 ul, 검색된 유저는 li로 변경





### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
모바일
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/6486abfb-42e1-4380-b89b-2fe785c958ba)
태블릿
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/78038988-aa01-4b87-8076-1321950dd622)
데스크탑
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/00b5c794-133c-4e7a-a7b4-09f0024bcb1d)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #359 

close: # 자기가 개발 전에 올린 이슈
