### PR TITLE
 [♻️ Refactor ]축제 리스트 IntersectionObserver로 관찰하여 무한스크롤 구현

### DIFF
--- a/src/Components/Product/ProductOutput.jsx
+++ b/src/Components/Product/ProductOutput.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { ProductAtom } from '../../Recoil/ProductAtom';
 
@@ -17,12 +17,37 @@ import { ProductContainer, ProductBox } from './ProductStyle';
 export default function ProductBundle() {
   const product = useRecoilValue(ProductAtom);
   const filteredProducts = product.filter(filterActive);
+  const [nextPage, setNextPage] = useState(4);
+
+  const handleObserver = useCallback((entries) => {
+    const [target] = entries;
+    console.log(target);
+    if (target.isIntersecting) {
+      setNextPage((prev) => prev + 4);
+    }
+  });
+  const observerElem = useRef(null);
+  useEffect(() => {
+    let options = {
+      root: null,
+      rootMargin: '10px',
+      threshold: 0.5,
+    };
+
+    const observer = new IntersectionObserver(handleObserver, options);
+    const element = observerElem.current;
+
+    if (element) observer.observe(element);
+    return () => {
+      if (element) observer.unobserve(element);
+    };
+  }, [handleObserver]);
 
   return (
     <>
       <TopNavigation />
       <ProductContainer>
-        {filteredProducts.slice(0).map((item, index) => (
+        {filteredProducts.slice(0, nextPage).map((item, index) => (
           <ProductBox key={index}>
             <Link to={`/product/detail/${item._id}`} key={index}>
               <ProductListImgBox src={item.itemImage} />
@@ -37,6 +62,7 @@ export default function ProductBundle() {
           </ProductBox>
         ))}
       </ProductContainer>
+      <div className='loader' ref={observerElem}></div>
     </>
   );
 }


### PR DESCRIPTION


<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
초기 렌더링 시간을 줄이기 위해 축제가 렌더링 되는 개수를 줄이고 IntersectionObserver로 관찰하여 true일 때 
축제 4개를 더 불러오는 방식으로 변경하였습니다.



### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
IntersectionObserver을 이용하여 구현하였고, get api에서 페이지네이션을 이용해 구현하려 하였으나 다른 조들과 db를 공유하여 사용하기 때문에 페이지네이션이 쉽지 않을거라 판단하여 이미 배열로 담은 filteredProducts 를 이용하여 
slice를 이용해 잘라서 렌더링하는 방식을 이용했습니다.



### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/335f6b29-3acb-4c28-bca7-a4689b018ac4)
useState의 초기값은 4이지만 8개가 불러와지는 것은 초기에 가장 밑에 존재하는 observerElem이 감지되어 4개를 같이 바로 불러와서 8개로 초기 렌더링이 되고 스크롤을 내려 observerElem이 감지되면 4개씩 렌더링 되도록 하였습니다.



### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
축제를 스크롤하여 다 불러오면 가장 밑에 스크롤이 있을 때 계속 관찰하여 콘솔에 관찰되었다는 로그가 무한으로 찍혀
기능 저하의 문제가 있습니다. 이 부분을 수정하겠습니다.



### 특이 사항 :
Issue Number #405 

close: # 자기가 개발 전에 올린 이슈
