### PR TITLE
[♻️ Refactor] 축제 등록 이미지 용량 압축

### DIFF
--- a/src/Utils/cropImage.js
+++ b/src/Utils/cropImage.js
@@ -51,7 +51,7 @@ export default async function getCroppedImg(imageSrc, pixelCrop) {
   ctx.putImageData(data, 0, 0);
 
   // As Base64 string
-  return canvas.toDataURL('image/jpeg');
+  return canvas.toDataURL('image/jpeg', 0.8);
 
   // As a blob
   // return new Promise((resolve) => {


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->




### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
cropImage.js의 return 문의 canvas.toDataURL에 두 번째 매개변수에 encoderOptions를 이용하여 
앞으로 등록 될 이미지의 용량을 줄였습니다.
https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
압축 전
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/850f9e1c-06e4-43f3-ba66-fb2f58dde4fa)

압축 후 
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/c61ffa16-d5bb-4e4a-b08f-477794ea2e84)

압축 전 대비 48퍼센트 감소하였습니다.

### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->
등록을 할 때 이미지의 품질을 결정하여 이미 등록이 된 이미지들의 용량은 줄어들지 않았습니다.



### 특이 사항 :
Issue Number #411 

close: # 자기가 개발 전에 올린 이슈
