### PR TITLE
[♻️ Refactor 🔧 Fix] 축제 등록 시 이미지의 비율마다 등록되지 않는 오류

### DIFF
--- a/src/Hooks/Common/useImage.jsx
+++ b/src/Hooks/Common/useImage.jsx
@@ -8,15 +8,53 @@ export const useImage = (initialImg) => {
   });
   const [prevImgData, setPrevImgData] = useState('');
 
+  const resizeImage = async (url, maxWidth, maxHeight) => {
+    return new Promise((resolve) => {
+      const img = new Image();
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        let newWidth, newHeight;
+
+        if (img.width > maxWidth || img.height > maxHeight) {
+          const aspectRatio = img.width / img.height;
+
+          if (aspectRatio > 1) {
+            newWidth = maxWidth;
+            newHeight = newWidth / aspectRatio;
+          } else {
+            newHeight = maxHeight;
+            newWidth = newHeight * aspectRatio;
+          }
+        } else {
+          newWidth = img.width;
+          newHeight = img.height;
+        }
+
+        canvas.width = newWidth;
+        canvas.height = newHeight;
+
+        ctx.drawImage(img, 0, 0, newWidth, newHeight);
+        resolve(canvas.toDataURL('image/jpeg'));
+      };
+
+      img.src = url;
+    });
+  };
+
   const onSelectFile = (e) => {
     e.preventDefault();
     if (e.target.files && e.target.files.length > 0) {
       const reader = new FileReader();
-      reader.addEventListener('load', () => {
+      reader.addEventListener('load', async () => {
         setPrevImgData(imgData.imageUrl); // 이전 이미지 저장
+
+        const resizedImageUrl = await resizeImage(reader.result, 700, 500);
+
         setImgData((prevImage) => ({
           ...prevImage,
-          imageUrl: reader.result?.toString() || '', // 새로운 이미지 설정
+          imageUrl: resizedImageUrl || '', // 새로운 이미지 설정
         }));
       });
       reader.readAsDataURL(e.target.files[0]);


### PR DESCRIPTION
<!-- [♻️ Refactor /✨ Feature/🚨Bug / 🔧 Fix/ 🌈 Style] PR 제목 -->

### 체크리스트!
- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?


### 변경사항 및 이유
<!-- 어떤 위험이나 장애가 발견되었는지 -->
축제 등록 시 이미지의 비율마다 등록되지 않는 오류가 있었습니다.


### 작업 내역
<!-- 어떻게 문제를 해결하였는지 -->
useImage.jsx에서 사용자가 등록한 이미지를 canvas를 생성하여 ctx.drawImage를 이용해 이미지를 그려 리사이징하였습니다.
제가 가진 이미지들로 테스트를 진행하였고(15장), 모든 이미지가 등록이 가능한 값으로 지정하였습니다.
700*500보다 큰 사이즈의 이미지는 700*500으로 리사이징을 실행하고, 700*500 보다 작다면 이미지의 현재 크기 그대로를 사용하게 하였습니다.
const resizedImageUrl = await resizeImage(reader.result, 700, 500);


### 작업 후 기대 동작(스크린샷) 
<!-- 작업 후 기대 동작(스크린샷) -->
기준 : 700 * 500

width,height 둘 다 클 때 적용
1400 * 720
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/c461cc22-179a-443c-ad2a-2cfd6265dfdc)
width만 기준보다 클 때 적용
870 * 370
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/c75e601e-bf59-48b3-b16b-01cd4bc5e0f7)
height만 기준보다 클 때 적용
500 * 625
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/9fedd599-b086-48e7-a390-d5badf66f9de)
크기가 매우 큰 이미지
6455 * 2709
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/c0b6eb11-00c9-493d-ad65-9f863539980d)
기존에 등록되지 않던 이미지
2000*460
![image](https://github.com/FRONTENDSCHOOL7/final-18-moamoa/assets/88381607/7ff351da-6271-4632-a827-1fe0ca31530e)




### PR 특이 사항
<!-- 어떤 부분에 리뷰어가 집중하면 좋을까요? -->




### 특이 사항 :
Issue Number #413 

close: #413 